### PR TITLE
FIX typos in WLFWP 210404, 210701, 220523

### DIFF
--- a/transcripts/wlfwp-210404-all-things-hormones-metabolism-and-health.vtt
+++ b/transcripts/wlfwp-210404-all-things-hormones-metabolism-and-health.vtt
@@ -22,10 +22,10 @@ WEBVTT
  And the fat, if you're fasting for a week or 10 days, they have found that the great
 
 00:00:44.160 --> 00:00:51.760
- maturity of the weight loss is in protein and water with hardly a dent in the fat.
+ majority of the weight loss is in protein and water with hardly a dent in the fat.
 
 00:00:51.760 --> 00:00:56.560
- Welcome to the Win It Life Podcast, a place where we share everything you need to know
+ Welcome to the Win At Life Podcast, a place where we share everything you need to know
 
 00:00:56.560 --> 00:01:00.880
  about restoring your metabolism so you can break free from restrictive diets
@@ -34,7 +34,7 @@ WEBVTT
  and build a body and life you love.
 
 00:01:02.800 --> 00:01:08.240
- I'm Kitty Bloomfield, co-founder of NuStrength and your host for this episode.
+ I'm Kitty Blomfield, co-founder of NuStrength and your host for this episode.
 
 00:01:08.240 --> 00:01:12.640
  Today, I'm sitting down with Dr. Ray Peat and my business partner and friend, Emma Sgourakis.
@@ -94,7 +94,7 @@ WEBVTT
  So I've got two amazing people on the podcast today, Dr. Ray Peat and Emma, everyone knows Emma,
 
 00:02:49.520 --> 00:02:52.400
- my friend and business partner in Saturay. Welcome.
+ my friend and business partner in Saturée. Welcome.
 
 00:02:52.400 --> 00:02:56.720
  Hi. Hi, Ray.
@@ -139,13 +139,13 @@ WEBVTT
  the first one is around polyunsaturated fat. So regarding polyunsaturated fatty acids, oils,
 
 00:04:13.280 --> 00:04:19.200
- pufas, as we refer to them, and their instability when exposed to heat by an oxygen that you've
+ PUFAs, as we refer to them, and their instability when exposed to heat by an oxygen that you've
 
 00:04:19.200 --> 00:04:24.000
  educated about for decades in the nutrition realm. How would you explain to someone new to
 
 00:04:24.000 --> 00:04:29.680
- this concern about pufas, the issues of applying them topically on the skin, and therefore how
+ this concern about PUFAs, the issues of applying them topically on the skin, and therefore how
 
 00:04:29.680 --> 00:04:34.960
  skincare products loaded with these oils should be reconsidered? Because Emma often talks about,
@@ -157,7 +157,7 @@ WEBVTT
  a very long time was use a lot of really crappy moisturizers and things and just rub them on my
 
 00:04:44.800 --> 00:04:54.240
- skin. So I'll just let you start with that question. The pufa question has been scientifically
+ skin. So I'll just let you start with that question. The PUFA question has been scientifically
 
 00:04:54.240 --> 00:05:08.400
  manipulated since about 1940. At that time, coconut oil was very popular as a better substitute of
@@ -220,7 +220,7 @@ WEBVTT
  turning into solid materials if the concentration is high. Otherwise, just breaking down into toxic
 
 00:08:21.040 --> 00:08:29.440
- fragments, besides stimulating fat production, they paint the fat so that in the future,
+ fragments, besides stimulating fat production, they taint the fat so that in the future,
 
 00:08:31.120 --> 00:08:39.680
  as you draw out these fats to metabolize, they are more poisonous than when they went in.
@@ -271,7 +271,7 @@ WEBVTT
  But this is build up of the dying skin cells. Several layers of compacted,
 
 00:11:05.360 --> 00:11:15.440
- kerogenized skin cells are impregnated with oil sebum formed by our skin oil glands.
+ keratinized skin cells are impregnated with oil sebum formed by our skin oil glands.
 
 00:11:16.480 --> 00:11:24.800
  So it's the same idea as putting grease on your boots to keep the water out. But the grease
@@ -313,7 +313,7 @@ WEBVTT
  Coconut oil has only 3% of the toxic oils. And so as much safer, butter is about 3%
 
 00:13:03.920 --> 00:13:14.320
- of the toxic oils. But butter, some of these toxic poofa, the small percentage in butter,
+ of the toxic oils. But butter, some of these toxic PUFAs, the small percentage in butter,
 
 00:13:14.320 --> 00:13:23.040
  some of them have been converted to trans fatty acids. And the trans fats, which are formed
@@ -334,7 +334,7 @@ WEBVTT
  oils to consume. And Ray, what about, could you talk about fish oil and krill oil? Because
 
 00:14:14.720 --> 00:14:20.160
- that's something that prior to finding UNMR, I used to take a heap of, I remember I competed
+ that's something that prior to finding you and Emma, I used to take a heap of, I remember I competed
 
 00:14:20.160 --> 00:14:24.800
  in some fitness competitions and at one point my coach had me taking eight tablets per day.
@@ -415,7 +415,7 @@ WEBVTT
  krill oil is just a small version that the animals have assimilated the
 
 00:18:24.640 --> 00:18:32.480
- algae, polyuns has been fattened, has it along to the bigger fish, but it's essentially the
+ algas polyunsaturated fats and pass it along to the bigger fish, but it's essentially the
 
 00:18:33.120 --> 00:18:43.200
  extremely mostly four and four and five double bonds in each molecule. And a great series of
@@ -463,7 +463,7 @@ WEBVTT
  that has only a mild effect on blocking the cell response, the transport and the formation
 
 00:20:54.720 --> 00:21:05.680
- of the thyroid hormone. But linoleic acid, a major poof of seed oils, it has twice the blocking
+ of the thyroid hormone. But linoleic acid, a major PUFA of seed oils, it has twice the blocking
 
 00:21:05.680 --> 00:21:14.400
  effect as the monounsaturated. Linolenic three times the effect, fish oil four to five times
@@ -529,10 +529,10 @@ WEBVTT
  The grass also naturally contains other nutrients, but the main thing is that the high vitamin E
 
 00:24:37.520 --> 00:24:45.680
- content is necessary for the cow to destroy the PUFA, the great maturity of the PUFA.
+ content is necessary for the cow to destroy the PUFA, the great majority of the PUFA.
 
 00:24:45.680 --> 00:24:52.720
- Great, thank you. Emma, did you have any more questions you wanted to ask around the PUFA's
+ Great, thank you. Emma, did you have any more questions you wanted to ask around the PUFAs
 
 00:24:52.720 --> 00:24:59.360
  and the skin? Yeah, it really comes to that conclusion, doesn't it, Kitty, as to why
@@ -541,13 +541,13 @@ WEBVTT
  we're doing what we're doing. With everything considered that you just talked about, Ray,
 
 00:25:05.520 --> 00:25:14.800
- in regards to PUFA's and their potential toxicity, and when we consider that some of the main pillars
+ in regards to PUFAs and their potential toxicity, and when we consider that some of the main pillars
 
 00:25:14.800 --> 00:25:25.200
  of that wellness industry, anti-aging kind of push, and you look at the PUFA-laden skincare products,
 
 00:25:25.200 --> 00:25:30.320
- the fish oils, eat more salmon, drink your carat juice, talking about carotene,
+ the fish oils, eat more salmon, drink your carrot juice, talking about carotene,
 
 00:25:30.320 --> 00:25:38.720
  it should be a reminder to everyone to question everything that they're being sold, and that
@@ -607,7 +607,7 @@ WEBVTT
  or a spreader of the free radical breakdown oxidizing process.
 
 00:28:26.560 --> 00:28:40.880
- That stimulates the production of plastic landons and a whole cascade of other inflammatory materials.
+ That stimulates the production of prostaglandins and a whole cascade of other inflammatory materials.
 
 00:28:40.880 --> 00:28:44.480
  Yeah, incredible.
@@ -658,7 +658,7 @@ WEBVTT
  When I was a kid, they were still feeding the pigs a better diet and their fat
 
 00:30:17.760 --> 00:30:26.800
- reflects very closely. Like chickens and pigs and other non-remanent animals, what they eat
+ reflects very closely. Like chickens and pigs and other non-ruminant animals, what they eat
 
 00:30:26.800 --> 00:30:37.440
  shows up very closely in their fat composition. For many years, even the government sources were
@@ -667,7 +667,7 @@ WEBVTT
  calling lard a saturated fat. Then an analysis about five years ago found that it was more than
 
 00:30:48.000 --> 00:31:00.480
- 30% poofa, extremely toxic with fat. Someone recently decided to try making safer pork,
+ 30% PUFA, extremely toxic with fat. Someone recently decided to try making safer pork,
 
 00:31:00.480 --> 00:31:12.960
  that they have a pork farm. By changing the diet, feeding them residue from, I think, a beer factory
@@ -676,10 +676,10 @@ WEBVTT
  and produce from their farms rather than a soy and corn-based diet, that they had the pork fat
 
 00:31:24.800 --> 00:31:37.040
- analyzed and rather than being 30-some percent poofa, theirs was slightly higher than butter,
+ analyzed and rather than being 30-some percent PUFA, theirs was slightly higher than butter,
 
 00:31:37.040 --> 00:31:46.640
- 4% a fraction over 4% poofa. Their pork would be extremely safe to eat because of the
+ 4% a fraction over 4% PUFA. Their pork would be extremely safe to eat because of the
 
 00:31:49.120 --> 00:31:54.880
  closeness to our natural high-body temperature stable fats.
@@ -724,7 +724,7 @@ WEBVTT
  ate butter for a long time and then I remember when she started switching us all over to margarine
 
 00:33:27.600 --> 00:33:36.000
- and we used to have nuttilex and it just tastes yucky compared to beautiful yummy butter. It's
+ and we used to have Nuttelex and it just tastes yucky compared to beautiful yummy butter. It's
 
 00:33:36.000 --> 00:33:43.360
  another example, isn't it? How industry, the financial interests and how powerful marketing
@@ -772,13 +772,13 @@ WEBVTT
  It's also nice for the chickens. You see those terrible cage farms where they're all shoved
 
 00:35:51.200 --> 00:35:57.360
- into those tiny little cages and they never get to see white. I think it's just like animal cruelty
+ into those tiny little cages and they never get to see light. I think it's just like animal cruelty
 
 00:35:57.360 --> 00:36:04.560
  as well. It's so awful for the animals. Absolutely. Do you have any more questions
 
 00:36:04.560 --> 00:36:10.000
- on PUFA's Emma? Emma's been working away on the skin care it's taken her a year and a half.
+ on PUFAs Emma? Emma's been working away on the skin care it's taken her a year and a half.
 
 00:36:10.000 --> 00:36:15.360
  Because she's just been trying to get something that's, yeah.
@@ -1120,7 +1120,7 @@ WEBVTT
  So you're taking care of the cortisol excess problem when you're doing the
 
 00:53:14.960 --> 00:53:19.600
- channel safe muscle building exercises.
+ gentle safe muscle building exercises.
 
 00:53:19.600 --> 00:53:25.760
  Awesome. Emma, did you have any other questions you want to ask around the diets?
@@ -1159,7 +1159,7 @@ WEBVTT
  the female hormone. Males, old men who were under stress, or younger men who had either a traumatic
 
 00:54:51.760 --> 00:55:02.240
- accident or is very sick, man's estrogen will rival the peak estrogen production of young women.
+ accident or is very sick, men's estrogen will rival the peak estrogen production of young women.
 
 00:55:03.600 --> 00:55:10.880
  So it's absolutely not a female hormone, it's just a stress-related or traumatic
@@ -1261,7 +1261,7 @@ WEBVTT
  create the situation they're now in, but to, yeah, work towards making the appropriate changes
 
 01:00:24.000 --> 01:00:32.480
- as kitty, you know, teachers. I think give it time, you know, you can't undo 20 years in 12 weeks.
+ as Kitty, you know, teaches. I think give it time, you know, you can't undo 20 years in 12 weeks.
 
 01:00:32.480 --> 01:00:40.400
  No, never. Yeah, I wish. We all want it to go faster. Do you have any more questions, Emma,
@@ -1324,7 +1324,7 @@ WEBVTT
  behind heart disease, where the actual mechanism known is that the breakdown of the polyunsaturated
 
 01:03:28.480 --> 01:03:37.520
- fats are creating, among other things, lipofuscan-like chemicals that irritate and inflame,
+ fats are creating, among other things, lipofuscin-like chemicals that irritate and inflame,
 
 01:03:37.520 --> 01:03:48.320
  first of all, the blood vessels. And that sets up a process in which cholesterol is detoxifying,
@@ -1339,7 +1339,7 @@ WEBVTT
  disease, as well as diabetes. But continuing research was showing that what causes diabetes
 
 01:04:21.120 --> 01:04:32.320
- is the, it's called the Randall effect. When you are forced in the stress to draw protein
+ is the, it's called the Randle effect. When you are forced into stress to draw protein
 
 01:04:32.320 --> 01:04:40.480
  or amino acids and fats out of your tissues, the free fatty acids in your bloodstream
@@ -1402,7 +1402,7 @@ WEBVTT
  happened in claiming that sugar causes or supports cancer. It came from completely
 
 01:07:50.800 --> 01:07:59.600
- misunderstanding or getting out of barberage researched backwards. He showed that in cancer
+ misunderstanding or getting Otto Warburg researche backwards. He showed that in cancer
 
 01:07:59.600 --> 01:08:09.920
  cells, the presence of oxygen no longer is able to suppress the formation of lactic acid.
@@ -1510,7 +1510,7 @@ WEBVTT
  Yeah, the insulin in the 1950s, they were already seen, possibly because it was made
 
 01:13:28.240 --> 01:13:37.360
- from pig pantherias, but it was turning out to be killing the death rate from diabetes
+ from pig pancreas, but it was turning out to be killing the death rate from diabetes
 
 01:13:37.360 --> 01:13:47.120
  increase after the introduction of insulin, oddly. So people were realizing that insulin
@@ -1594,7 +1594,7 @@ WEBVTT
  and had maybe a two-month life expectancy, feeding them all the sugar they wanted.
 
 01:17:52.160 --> 01:17:58.720
- They reasoned they were going to die soon, so quite tortured them by depriving them of what
+ They reasoned they were going to die soon, so quit tortured them by depriving them of what
 
 01:17:58.720 --> 01:18:07.600
  they were craving. And it happened that giving them a regular diet of beef and potatoes and milk
@@ -1615,7 +1615,7 @@ WEBVTT
  keeping the blood sugar up to their cravings was lowering their cortisol, stopping the destruction
 
 01:18:54.320 --> 01:19:01.760
- of their tissues, also stopping the poisoning of the pancreas with the three fatty acids.
+ of their tissues, also stopping the poisoning of the pancreas with the free fatty acids.
 
 01:19:01.760 --> 01:19:09.440
  So it actually turned around the fatal disease. It helped them make their own glucose
@@ -1627,7 +1627,7 @@ WEBVTT
  The beef, the glucose, or the sugar causes diabetes, was sustained and became part of
 
 01:19:31.120 --> 01:19:39.280
- the background of the insulin treatment and then of the metformin. I think ten-formin was the
+ the background of the insulin treatment and then of the Metformin. I think Tenformin was the
 
 01:19:40.160 --> 01:19:45.600
  preceding, very toxic glucose waster.
@@ -1804,7 +1804,7 @@ WEBVTT
  because supposedly it's an essential nutrient but what they're selling is is a highly degraded form
 
 01:28:33.040 --> 01:28:42.960
- of it isn't that scary to criminals women who are formula feeding their babies and that have no idea
+ of it. Isn't that scary to criminalize women who are formula feeding their babies and that have no idea
 
 01:28:42.960 --> 01:28:50.480
  it's just encouraged it's just it's it's a big reminder isn't it that we need to you know keep
@@ -1813,13 +1813,13 @@ WEBVTT
  practicing common sense um you know the marketing is strong and the pressures are strong but it's
 
 01:28:57.680 --> 01:29:03.680
- bring it back to simplicity do you have any more around the sugar before i move on to the next
+ bring it back to simplicity do you have any more around the sugar before I move on to the next
 
 01:29:03.680 --> 01:29:11.520
  question Emma uh no no that's fantastic yeah it's good eat the sugar everyone plus it's Haitian
 
 01:29:11.520 --> 01:29:16.800
- and when you crave it you crave it for a reason yeah just stop and obviously i mean it's it's
+ and when you crave it you crave it for a reason yeah just stop and obviously I mean it's it's
 
 01:29:16.800 --> 01:29:20.400
  again common sense but when you when you get that overwhelming sugar craving
@@ -1855,7 +1855,7 @@ WEBVTT
  will if you use it on the skin or have enough from internal use of coffee the caffeine is powerfully
 
 01:30:37.200 --> 01:30:45.600
- protecting against proof of breakdown in the skin it quenches and blocks free radical damage
+ protecting against PUFA breakdown in the skin it quenches and blocks free radical damage
 
 01:30:46.480 --> 01:30:53.440
  is both anti-inflammatory and anti-oxidative in the skin protects against skin cancer
@@ -1867,34 +1867,34 @@ WEBVTT
  so coffee isn't just a stimulant drug but it's it's an extremely powerful protective factor
 
 01:31:13.360 --> 01:31:17.120
- actually on that topic kitty you and i were just discussing this recently but
+ actually on that topic Kitty you and I were just discussing this recently but
 
 01:31:17.120 --> 01:31:24.320
- this is for me way back in my first pregnancy when i discovered years ray a couple of years
+ this is for me way back in my first pregnancy when I discovered years Ray a couple of years
 
 01:31:24.320 --> 01:31:30.640
- before that but i um we were talking about coffee and i'd never been a coffee drinker because i was
+ before that but I um we were talking about coffee and I'd never been a coffee drinker because I was
 
 01:31:30.640 --> 01:31:35.360
- in the health world and coffee is not a good thing apparently or so i thought and the more
+ in the health world and coffee is not a good thing apparently or so I thought and the more
 
 01:31:35.360 --> 01:31:41.360
- research i did the more i figured that actually coffee is incredible so when most women embark
+ research I did the more I figured that actually coffee is incredible so when most women embark
 
 01:31:41.360 --> 01:31:46.160
  on pregnancy one of the first things they recommended is cut back on or avoid coffee
 
 01:31:46.160 --> 01:31:53.120
- completely i actually took up coffee drinking as you know as i was pregnant um and that's when
+ completely I actually took up coffee drinking as you know as I was pregnant um and that's when
 
 01:31:53.120 --> 01:31:57.840
- i brought it into my diet having learnt about all its protective factors and the importance
+ I brought it into my diet having learnt about all its protective factors and the importance
 
 01:31:57.840 --> 01:32:03.040
- for the baby's lung development and so many other things so i was i was doing the opposite but
+ for the baby's lung development and so many other things so I was I was doing the opposite but
 
 01:32:03.040 --> 01:32:08.480
- that's when i you know learnt to embrace coffee and you know haven't let it go since obviously
+ that's when I you know learnt to embrace coffee and you know haven't let it go since obviously
 
 01:32:08.480 --> 01:32:13.040
  because you come to love it as well but it's um you know quite a controversial topic because
@@ -1912,7 +1912,7 @@ WEBVTT
  would get the shakes and feel very stressed if she had even half a cup of coffee but she was
 
 01:32:42.720 --> 01:32:49.600
- taking it on an empty stomach and not using cream or sugar in it i suggested that she
+ taking it on an empty stomach and not using cream or sugar in it I suggested that she
 
 01:32:49.600 --> 01:32:58.480
  start with a small amount adding cream and having it with breakfast in just a few days of doing that
@@ -1939,7 +1939,7 @@ WEBVTT
  eaten with or after food and sugar and milk or creams involved um coffee should actually
 
 01:33:49.120 --> 01:33:54.480
- come in person as opposed to induce stress and if it's if it's inducing any kind of stress
+ calm a person as opposed to induce stress and if it's if it's inducing any kind of stress
 
 01:33:54.480 --> 01:33:59.840
  whatsoever you should reassess pull back and look at your diet as a whole and how you're doing it
@@ -1948,34 +1948,34 @@ WEBVTT
  because it should be something that you know only adds to your well-being when it's done correctly
 
 01:34:05.040 --> 01:34:10.880
- even i noticed now um you know because obviously before i met you and fan ray i was you know
+ even I noticed now um you know because obviously before I met you and fan Ray I was you know
 
 01:34:10.880 --> 01:34:15.440
- getting up drinking the black coffee empty stomach now i'll have a big breakfast with eggs
+ getting up drinking the black coffee empty stomach now I'll have a big breakfast with eggs
 
 01:34:15.440 --> 01:34:21.120
- and parmesan cheese and lots of fruit and then i'll have the coffee and i have a cup of milk with it
+ and parmesan cheese and lots of fruit and then I'll have the coffee and I have a cup of milk with it
 
 01:34:21.120 --> 01:34:27.040
- and i have sugar and collagen but even now i noticed if i don't have adequate carbs with it
+ and I have sugar and collagen but even now I noticed if I don't have adequate carbs with it
 
 01:34:27.040 --> 01:34:33.280
- i noticed that i have get low blood sugar symptoms after but as soon as i add more fruit or add more
+ I noticed that I have get low blood sugar symptoms after but as soon as I add more fruit or add more
 
 01:34:33.280 --> 01:34:38.000
- sugar i feel nice and balanced after it's just really interesting i think when you just even
+ sugar I feel nice and balanced after it's just really interesting I think when you just even
 
 01:34:38.000 --> 01:34:49.440
- experiment on yourself you can notice these things uh yeah i i got conscious of of the effects of
+ experiment on yourself you can notice these things uh yeah I I got conscious of of the effects of
 
 01:34:49.440 --> 01:35:00.000
- protein one morning when i had uh uh uh to be in a hurry i ate just a couple of scrambled eggs
+ protein one morning when I had uh uh uh to be in a hurry I ate just a couple of scrambled eggs
 
 01:35:00.000 --> 01:35:06.720
  and didn't have my usual uh milk and juice and at that time potatoes or something with them
 
 01:35:07.360 --> 01:35:15.360
- and for the next several hours i was having extreme hypoglycemia and i realized that
+ and for the next several hours I was having extreme hypoglycemia and I realized that
 
 01:35:15.360 --> 01:35:24.240
  that very often happens with eggs dieting women will very often have a breakfast of
@@ -1987,52 +1987,52 @@ WEBVTT
  sugar to back it up and so very quickly after eating two eggs you can suffer hypoglycemia
 
 01:35:49.360 --> 01:35:58.080
- if your liver isn't well stocked with glucose so with one egg i find that it takes at least
+ if your liver isn't well stocked with glucose so with one egg I find that it takes at least
 
 01:35:58.080 --> 01:36:05.120
  10 ounces of orange juice not to have a drop in the blood sugar so with two eggs
 
 01:36:05.120 --> 01:36:12.720
- it's more like a pint of orange juice to balance it yeah i think because women are so and we've
+ it's more like a pint of orange juice to balance it yeah I think because women are so and we've
 
 01:36:12.720 --> 01:36:17.520
- talked about the sugar and carbs like i used to be so scared of sugar and carbs but when i
+ talked about the sugar and carbs like I used to be so scared of sugar and carbs but when i
 
 01:36:17.520 --> 01:36:22.720
- actually started to track my food and experiment i realized oh how much carbs i actually needed and
+ actually started to track my food and experiment I realized oh how much carbs I actually needed and
 
 01:36:22.720 --> 01:36:29.200
- you know obviously in time after i you know ate more and stopped flogging myself with cardio and
+ you know obviously in time after I you know ate more and stopped flogging myself with cardio and
 
 01:36:29.200 --> 01:36:35.280
  doing more strength training and just lowering all the stress my body's it seemed like my body's
 
 01:36:35.280 --> 01:36:41.280
- ability to handle carbs just became better and better and now you know i eat quite a lot of carbs
+ ability to handle carbs just became better and better and now you know I eat quite a lot of carbs
 
 01:36:41.280 --> 01:36:46.320
- and sometimes i even surprise myself and think oh wow it's amazing how much you actually how much
+ and sometimes I even surprise myself and think oh wow it's amazing how much you actually how much
 
 01:36:46.320 --> 01:36:52.960
- i actually eat now um but i think so many women are so scared to eat carbs because they've just
+ I actually eat now um but I think so many women are so scared to eat carbs because they've just
 
 01:36:52.960 --> 01:36:57.440
  been so demonized or they've restricted for such a long period of time you know they're
 
 01:36:57.440 --> 01:37:03.120
- things have all been their metabolism's down regulated um and you know as soon as they eat
+ things have all been their metabolism's downregulated um and you know as soon as they eat
 
 01:37:03.120 --> 01:37:09.840
- the carbs they start to gain weight um and you know like women i think we're all anyone who's
+ the carbs they start to gain weight um and you know like women I think we're all anyone who's
 
 01:37:09.840 --> 01:37:14.560
- died for a long period of time we just get so obsessed with our weight and i think a lot of
+ diet for a long period of time we just get so obsessed with our weight and I think a lot of
 
 01:37:14.560 --> 01:37:19.200
  women find that hard initially when they're introducing the carbs would you find that too
 
 01:37:19.200 --> 01:37:27.520
- emma oh sorry yeah absolutely um it's something that they don't want to see even a you know a
+ Emma oh sorry yeah absolutely um it's something that they don't want to see even a you know a
 
 01:37:27.520 --> 01:37:33.520
  kilogram appear but perhaps their you know impression of themselves and where they should
@@ -2044,10 +2044,10 @@ WEBVTT
  how long have they been in this depleted state and potentially running on stress and there's
 
 01:37:45.600 --> 01:37:50.240
- probably an in just adjustment period in between where the body's going to need a few extra
+ probably an adjustment period in between where the body's going to need a few extra
 
 01:37:50.240 --> 01:37:55.760
- kilos on it to help it repair and ray this relates just to this question it's not in the
+ kilos on it to help it repair and Ray this relates just to this question it's not in the
 
 01:37:55.760 --> 01:38:01.360
  questions but just made me think of it while we're talking about weight um and body composition you
@@ -2083,13 +2083,13 @@ WEBVTT
  much you know when would you say what percentage like is it getting to be a real problem because
 
 01:39:23.600 --> 01:39:30.640
- i think that women you know um really want to be lean you know like when how low is too low
+ I think that women you know um really want to be lean you know like when how low is too low
 
 01:39:30.640 --> 01:39:41.120
- um the ones that i've seen having problems it was done in the teens
+ um the ones that I've seen having problems it was done in the teens
 
 01:39:42.320 --> 01:39:48.080
- wow so you think you know like emma and i have talked about this i know obviously you can't go
+ wow so you think you know like Emma and I have talked about this I know obviously you can't go
 
 01:39:48.080 --> 01:39:52.880
  this is exact body fat percentage because everyone's different and you know like you want to look at
@@ -2101,40 +2101,40 @@ WEBVTT
  under 23 under 24 like you know when does it start to be you know you mentioned teens under 20s and
 
 01:40:04.480 --> 01:40:09.520
- i've been very low body fat under in under 20 percent and i experienced lots of issues you know
+ I've been very low body fat under in under 20 percent and I experienced lots of issues you know
 
 01:40:09.520 --> 01:40:15.840
- poor sleep irregular cycles um now i'm obviously my body fat's a lot higher and i feel a lot better
+ poor sleep irregular cycles um now I'm obviously my body fat's a lot higher and I feel a lot better
 
 01:40:15.840 --> 01:40:21.840
  so you know like do you think 22 percent's too low or would you say more getting to under those 20s
 
 01:40:21.840 --> 01:40:31.280
- i think that's sort of the the borderline range i think people are usually
+ I think that's sort of the the borderline range I think people are usually
 
 01:40:32.960 --> 01:40:41.760
  generally feeling better when it's a little over 25 percent and probably 25 percent is safe
 
 01:40:41.760 --> 01:40:47.120
- yeah which is like you know i think a lot of women will listen to this and go wow
+ yeah which is like you know I think a lot of women will listen to this and go wow
 
 01:40:47.120 --> 01:40:50.320
- hey emma like you and i emma and i were messaging about this because
+ hey Emma like you and I Emma and I were messaging about this because
 
 01:40:50.320 --> 01:40:55.120
- well i get lots of questions about it and women are like i really want to be lean kitty i want to
+ well I get lots of questions about it and women are like I really want to be lean Kitty I want to
 
 01:40:55.120 --> 01:41:00.240
- be lean um but they're also struggling with so many of the other issues and i think the fitness
+ be lean um but they're also struggling with so many of the other issues and I think the fitness
 
 01:41:00.240 --> 01:41:08.240
- industry really portrays that like lean look as healthy yeah and i guess it's your priorities
+ industry really portrays that like lean look as healthy yeah and I guess it's your priorities
 
 01:41:08.240 --> 01:41:12.960
- isn't it it's they'll say i want to be lean but we should twist that around a bit and say i want
+ isn't it it's they'll say I want to be lean but we should twist that around a bit and say I want
 
 01:41:12.960 --> 01:41:18.800
- to feel good i want to sleep well i want to keep stress down i want to look you know look good and
+ to feel good I want to sleep well I want to keep stress down I want to look you know look good and
 
 01:41:18.800 --> 01:41:25.840
  look young in my skin um and just leanness being you know the top of their list which does not
@@ -2149,7 +2149,7 @@ WEBVTT
  office work both men and women worked better more efficiently if they were getting at least
 
 01:41:55.520 --> 01:42:06.800
- a hundred grams of good protein every day i would consider 80 grams of good protein
+ a hundred grams of good protein every day I would consider 80 grams of good protein
 
 01:42:06.800 --> 01:42:16.240
  sort of a minimum but according to the army study the actual health and productivity was
@@ -2167,22 +2167,22 @@ WEBVTT
  anabolic for muscle so you can actually push the anabolic effect with increased protein
 
 01:42:55.360 --> 01:43:05.040
- but i think for longevity it's better to skimp on on protein as long as you're keeping your
+ but I think for longevity it's better to skimp on on protein as long as you're keeping your
 
 01:43:05.040 --> 01:43:09.280
  your carbohydrate up so that you don't experience stress
 
 01:43:12.800 --> 01:43:15.920
- do you have any more questions around that well before i move to the next question
+ do you have any more questions around that well before I move to the next question
 
 01:43:15.920 --> 01:43:21.360
- yeah you can move on that's great um so ray could you please comment on uh because we get
+ yeah you can move on that's great um so Ray could you please comment on uh because we get
 
 01:43:21.360 --> 01:43:25.840
  so many women you know again have done all the restrictive diets and then they have all of these
 
 01:43:25.840 --> 01:43:31.840
- cycle irregularities like i did or they'll have miscarriages can you please talk about
+ cycle irregularities like I did or they'll have miscarriages can you please talk about
 
 01:43:31.840 --> 01:43:42.880
  what actually causes this uh yeah stress increases your estrogen to progesterone ratio
@@ -2254,7 +2254,7 @@ WEBVTT
  not only the female hormone but was helpful for pregnancy and preventing miscarriages so they
 
 01:47:22.480 --> 01:47:32.400
- sold DES diethyl stilbestrol until in the 1950s they were selling it with
+ sold DES diethylstilbestrol until in the 1950s they were selling it with
 
 01:47:32.400 --> 01:47:42.720
  support from Harvard Medical School and the FDA and so on selling it to prevent
@@ -2299,7 +2299,7 @@ WEBVTT
  when I went to see the doctor they're like just take the pill or you know get an IUD put in or
 
 01:49:23.600 --> 01:49:27.840
- get the copper get the marina get the copper IUD get the I don't know what the shot's called the
+ get the copper get the Mirena get the copper IUD get the I don't know what the shot's called the
 
 01:49:27.840 --> 01:49:33.760
  dipper I can't remember what it's called and then you know the bar so you know could you just talk
@@ -2320,7 +2320,7 @@ WEBVTT
  and even though for years progesterone was recognized to block endometriosis
 
 01:50:26.880 --> 01:50:35.440
- the easiest way to do it is to supplement thyroid to lower the estrogen file raising
+ the easiest way to do it is to supplement thyroid to lower the estrogen while raising
 
 01:50:35.440 --> 01:50:47.920
  the progesterone and the effect of the pill they they knew in the 1930s that the pill creates
@@ -2332,10 +2332,10 @@ WEBVTT
  and they didn't want to call it the miscarriage pill so they invented the theory that it's
 
 01:51:04.640 --> 01:51:11.840
- preventing population there is never any confirmation that it really prevented
+ preventing ovulation there is never any confirmation that it really prevented
 
 01:51:11.840 --> 01:51:21.840
- population but it does block the production of of progesterone and so the lining of the uterus
+ ovulation but it does block the production of of progesterone and so the lining of the uterus
 
 01:51:21.840 --> 01:51:31.520
  is thinner progesterone is what thickens and matures lining of the uterus
@@ -2437,13 +2437,13 @@ WEBVTT
  in the aging hamster all of their tissues showed increased influence of estrogen
 
 01:56:07.600 --> 01:56:19.520
- with aging and one of our lab people Cherry Parkening later went on when the assays for
+ with aging and one of our lab people Gerald E. Parkening later went on when the assays for
 
 01:56:19.520 --> 01:56:28.080
  the actual tissue content of estrogen became available he showed that in other animals the
 
 01:56:28.080 --> 01:56:38.640
- actual tissue content of estrogen increased in old age i was just showing that the signs of estrogen
+ actual tissue content of estrogen increased in old age I was just showing that the signs of estrogen
 
 01:56:38.640 --> 01:56:46.000
  were all increased in old age and when you measure estrogen in the blood
@@ -2554,7 +2554,7 @@ WEBVTT
  menstruating and she looked like a very healthy woman in her 30s but she was 63. Wow amazing.
 
 02:02:00.560 --> 02:02:10.640
- We love progesty. Oh yeah just gonna bathe in it. Any other questions Emma? We're nearly there
+ We love Porgest-e. Oh yeah just gonna bathe in it. Any other questions Emma? We're nearly there
 
 02:02:10.640 --> 02:02:18.960
  so poor Ray is probably thinking of it. Another food I think that's been really demonized and
@@ -2617,7 +2617,7 @@ WEBVTT
  extends to milk and to call it something almond milk or soy milk or oat milk it's just ridiculous
 
 02:05:10.880 --> 02:05:24.320
- because they're equating milk with any fight emulsion that holds oil in a suspension that
+ because they're equating milk with any white emulsion that holds oil in a suspension that
 
 02:05:24.320 --> 02:05:32.320
  makes the milk mimics the water turn white has nothing to do with milk it's it's really a
@@ -2632,13 +2632,13 @@ WEBVTT
  antagonism towards breastfeeding is spreading over to milk in general
 
 02:06:02.560 --> 02:06:13.680
- but i think there's along that same history the social meaning of of women and femininity
+ but I think there's along that same history the social meaning of of women and femininity
 
 02:06:13.680 --> 02:06:23.840
- has changed and i think there's a lot of misogyny involved in people who are neurotically
+ has changed and I think there's a lot of misogyny involved in people who are neurotically
 
 02:06:24.640 --> 02:06:34.480
- hating milk there are lots of people who refuse to eat anything white like the fight of an egg
+ hating milk there are lots of people who refuse to eat anything white like the white of an egg
 
 02:06:34.480 --> 02:06:42.080
  because it resembles milk it has become a real borderline psychotic condition
@@ -2650,10 +2650,10 @@ WEBVTT
  any kind of event that happens gets blamed on on milk absolutely the opposite of what
 
 02:07:06.000 --> 02:07:14.320
- the real biological effects are so rave someone had trouble tolerating milk so they drank milk
+ the real biological effects are so Ray someone had trouble tolerating milk so they drank milk
 
 02:07:14.320 --> 02:07:18.800
- or eight dairy products and they got an upset stomach you know runs bloating gas why is that
+ or ate dairy products and they got an upset stomach you know runs bloating gas why is that
 
 02:07:18.800 --> 02:07:31.520
  usually because they're hypothyroid and the antibodies that are important for governing
@@ -2692,7 +2692,7 @@ WEBVTT
  a good endocrine function to restore those enzymes
 
 02:09:13.120 --> 02:09:18.560
- so i guess if you're someone who can't tolerate dairy then i guess go slow
+ so I guess if you're someone who can't tolerate dairy then I guess go slow
 
 02:09:18.560 --> 02:09:23.520
  is the takeaway when you reintroduce it just introduce a little bit and then gradually build
@@ -2719,7 +2719,7 @@ WEBVTT
  that you're excreting the progesterone at an abnormally high rate that's why the body
 
 02:10:32.320 --> 02:10:40.320
- stops producing so much estrogen for two weeks of the month to let the river liver reset
+ stops producing so much estrogen for two weeks of the month to let the liver reset
 
 02:10:40.320 --> 02:10:47.680
  its enzymes so that a moderate amount of estrogen of progesterone has its full effect
@@ -2728,37 +2728,37 @@ WEBVTT
  that happens with anything you're exposed to the enzymes will adapt to it if you give them
 
 02:10:56.560 --> 02:11:06.160
- if the tissue a couple of weeks Emma do you have any other questions or anything else to add
+ the tissue a couple of weeks Emma do you have any other questions or anything else to add
 
 02:11:06.160 --> 02:11:12.480
- no that's great thanks for that clarification ray and i think again it sort of goes slow like you
+ no that's great thanks for that clarification Ray and I think again it sort of goes slow like you
 
 02:11:12.480 --> 02:11:18.800
- said kitty and it's amazing what the body can do and the functions that can that can be reinstated
+ said Kitty and it's amazing what the body can do and the functions that can that can be reinstated
 
 02:11:18.800 --> 02:11:20.400
  when you give the body time
 
 02:11:20.400 --> 02:11:28.000
- yeah it's fascinating and dairy is so delicious too i can't imagine now not eating ice cream every
+ yeah it's fascinating and dairy is so delicious too I can't imagine now not eating ice cream every
 
 02:11:28.000 --> 02:11:34.080
  day or cheese it's even the terminology isn't it when people call you know soy milk or nut milk a
 
 02:11:34.080 --> 02:11:39.360
- replacement for dairy milk it's it's but by no way is it a replacement it doesn't replace
+ replacement for dairy milk it's but by no way is it a replacement it doesn't replace
 
 02:11:39.360 --> 02:11:44.640
- the loss of protein doesn't replace the the calcium levels by any means the minerals
+ the loss of protein doesn't replace the calcium levels by any means the minerals
 
 02:11:44.640 --> 02:11:54.640
- it's it doesn't even yeah and and they all contain polyunsaturated fats that slow your metabolism
+ it doesn't even yeah and and they all contain polyunsaturated fats that slow your metabolism
 
 02:11:54.640 --> 02:12:04.800
  and increase your tendency to gain fat where many studies show that milk besides the high calcium
 
 02:12:04.800 --> 02:12:16.560
- content and adequate magnesium content it high an increase of milk in your diet is the single
+ content and adequate magnesium content an increase of milk in your diet is the single
 
 02:12:16.560 --> 02:12:19.520
  simplest way to lose excess fat
@@ -2773,22 +2773,22 @@ WEBVTT
  still lose weight actually just one quick question then we'll wrap it up because it just made me
 
 02:12:47.600 --> 02:12:52.320
- think about a question i get all the time um you know of course you want to try and get the best
+ think about a question I get all the time you know of course you want to try and get the best
 
 02:12:52.320 --> 02:12:58.400
- quality milk that you can from pasture-raised um animals but uh and i know i've spoken to this
+ quality milk that you can from pasture-raised animals and I know I've spoken to this
 
 02:12:58.400 --> 02:13:03.200
- to emma about this all the time a lot you know women come into our program and they're on you
+ to Emma about this all the time a lot you know women come into our program and they're on you
 
 02:13:03.200 --> 02:13:12.560
- know on a tight budget not everyone can afford to buy raw um you know uh organic uh milk is it okay
+ know on a tight budget not everyone can afford to buy raw you know organic milk is it okay
 
 02:13:12.560 --> 02:13:20.400
- just to drink you know like you mentioned one percent pasteurized milk uh yeah that's what i
+ just to drink you know like you mentioned one percent pasteurized milk ? Yeah that's what I
 
 02:13:20.400 --> 02:13:28.800
- drink in the u.s generally but i go by the taste of it different brands taste better than others
+ drink in the US generally but I go by the taste of it different brands taste better than others
 
 02:13:28.800 --> 02:13:37.360
  and uh that usually means that they they aren't putting bad additives in the milk
@@ -2797,10 +2797,10 @@ WEBVTT
  but uh the ideal thing is to get a one percent milk straight from the the dairy before they've
 
 02:13:47.520 --> 02:13:54.880
- added anything to it in the u.s they require that one percent milk contain added vitamins
+ added anything to it in the US they require that one percent milk contain added vitamins
 
 02:13:54.880 --> 02:14:01.840
- a and d but to add those they use an emulsifier which can be allergenic
+ A and D but to add those they use an emulsifier which can be allergenic
 
 02:14:01.840 --> 02:14:13.280
  so if a person has uh some kind of an allergic symptom from the vitamin added milk
@@ -2809,61 +2809,61 @@ WEBVTT
  then they can worry about getting it direct from the the farm without added vitamins
 
 02:14:20.720 --> 02:14:28.240
- so you don't necessarily need to drink raw milk i don't know there's a small difference
+ so you don't necessarily need to drink raw milk I don't know there's a small difference
 
 02:14:28.240 --> 02:14:35.120
- in nutrition but uh pasteurize is fine so just yeah i mean we're quite lucky in
+ in nutrition but uh pasteurize is fine so just yeah I mean we're quite lucky in
 
 02:14:35.120 --> 02:14:39.840
- australia aren't we emma our milk is just we don't have there's only very few brands that have the
+ Australia aren't we Emma our milk is just we don't have there's only very few brands that have the
 
 02:14:39.840 --> 02:14:52.160
- added vitamins in australia i don't know about the availability of low-fat milk without vitamins
+ added vitamins in Australia I don't know about the availability of low-fat milk without vitamins
 
 02:14:52.160 --> 02:15:00.160
  usually the the whole milk doesn't have added vitamins yeah we're really very really lucky here
 
 02:15:00.160 --> 02:15:05.760
- ray we are like the majority of our milk doesn't have the added vitamins in australia i notice a
+ Ray we are like the majority of our milk doesn't have the added vitamins in Australia I notice a
 
 02:15:05.760 --> 02:15:10.240
- lot of our u.s clients always say oh it's really hard to find the low-fat milk without those added
+ lot of our US clients always say oh it's really hard to find the low-fat milk without those added
 
 02:15:10.240 --> 02:15:20.000
- vitamins yeah the uh i've heard that the emulsifier they use contains polyethylene glycol
+ vitamins yeah I've heard that the emulsifier they use contains polyethylene glycol
 
 02:15:20.000 --> 02:15:26.080
  and polysorbate 80 both of which are potentially dangerous allergens
 
 02:15:26.080 --> 02:15:30.960
- wow okay great that's awesome emma do you have anything else to add
+ wow okay great that's awesome Emma do you have anything else to add
 
 02:15:32.800 --> 02:15:39.120
- what was that oh i'm just asking emma if she has anything else to add i think she's just got her
+ what was that oh I'm just asking Emma if she has anything else to add I think she's just got her
 
 02:15:39.120 --> 02:15:49.760
- phone on um on silent sorry sorry i was just saying we're lucky here aren't we emma with the milk
+ phone on um on silent sorry sorry I was just saying we're lucky here aren't we Emma with the milk
 
 02:15:49.760 --> 02:15:55.600
- we're lucky in australia yeah it's not been made a rule that reduced fat milk has to have those
+ we're lucky in Australia yeah it's not been made a rule that reduced fat milk has to have those
 
 02:15:55.600 --> 02:16:00.240
  vitamins added so we can just have them with the fat removed and nothing else added um there's
 
 02:16:00.240 --> 02:16:06.800
- a few that you know you can choose by choice that have added vitamin d but um most of them are just
+ a few that you know you can choose by choice that have added vitamin D but um most of them are just
 
 02:16:06.800 --> 02:16:12.320
- yeah the fat removed and nothing else added to them and i mean of course if i had some cows sitting
+ yeah the fat removed and nothing else added to them and I mean of course if I had some cows sitting
 
 02:16:12.320 --> 02:16:18.000
- at the back of my house you know if i had a farm i'd be eating the raw drinking the raw milk and
+ at the back of my house you know if I had a farm I'd be eating the raw drinking the raw milk and
 
 02:16:18.000 --> 02:16:21.760
- eating the raw cheese but i think a lot of clients get really worried they're like oh kitty you know
+ eating the raw cheese but I think a lot of clients get really worried they're like oh Kitty you know
 
 02:16:21.760 --> 02:16:26.800
- i can't afford to buy all this raw organic milk and organic products and it's good to know that
+ I can't afford to buy all this raw organic milk and organic products and it's good to know that
 
 02:16:26.800 --> 02:16:31.520
  you know you can just you know get your good old regular milk with nothing else added
@@ -2872,16 +2872,16 @@ WEBVTT
  low fat and that's still going to be fine
 
 02:16:33.120 --> 02:16:39.760
- yeah no we've got good options here i think
+ yeah no we've got good options here I think
 
 02:16:39.760 --> 02:16:45.680
- well that's um we might wrap it up now ray i'm so sorry we've taken up so much of your
+ well that's um we might wrap it up now Ray I'm so sorry we've taken up so much of your
 
 02:16:45.680 --> 02:16:50.400
  time it's just once you get on a roll and then we have all these other questions
 
 02:16:50.400 --> 02:16:56.000
- you're just a wealth of knowledge i really appreciate you coming on and on the podcast i
+ you're just a wealth of knowledge I really appreciate you coming on and on the podcast I
 
 02:16:56.000 --> 02:17:00.800
  just was just thinking oh wow there's just so much great information in there that our

--- a/transcripts/wlfwp-210701-vitamin-D-calcium-and-mineral-metabolism.vtt
+++ b/transcripts/wlfwp-210701-vitamin-D-calcium-and-mineral-metabolism.vtt
@@ -4,7 +4,7 @@ WEBVTT
  [Music]
 
 00:00:04.880 --> 00:00:12.640
- I think it's the situation between the cholecalciferol or the 25-hydroxyform and the 125-dihydroxy.
+ I think it's the situation between the cholecalciferol or the 25-hydroxyform and the 1,25-dihydroxy.
 
 00:00:12.640 --> 00:00:17.680
  The relationship is very analogous to what happens when your thyroid is low,
@@ -31,22 +31,22 @@ WEBVTT
  the body goes into an emergency reaction in which at the same time that it's trying to correct
 
 00:01:04.720 --> 00:01:13.440
- deficiency, it's turning on a substance such as 125-dihydroxy D or luteinizing hormone or thyroid
+ deficiency, it's turning on a substance such as 1,25-dihydroxy D or luteinizing hormone or thyroid
 
 00:01:13.440 --> 00:01:19.840
  stimulating hormone, which in the process of adjusting has lots of dangerous toxic side effects.
 
 00:01:19.840 --> 00:01:28.160
- In the case of 125-hydroxy G, these unwindered side effects include obesity and osteoporosis.
+ In the case of 1,25-hydroxy D, these unwindered side effects include obesity and osteoporosis.
 
 00:01:28.160 --> 00:01:34.160
- Welcome to the Win It Life Podcast, a place where we share everything you need to know
+ Welcome to the Win At Life Podcast, a place where we share everything you need to know
 
 00:01:34.160 --> 00:01:39.520
  about restoring your metabolism so you can break free from restrictive diets and build a body and
 
 00:01:39.520 --> 00:01:44.880
- life you love. I'm Kitty Bloomfield, co-founder of NuStrength and your host for this episode and
+ life you love. I'm Kitty Blomfield, co-founder of NuStrength and your host for this episode and
 
 00:01:44.880 --> 00:01:49.600
  today we're joined by our good friend Kate Deering, author of How to Heal Your Metabolism for those
@@ -85,7 +85,7 @@ WEBVTT
  calcified that you need to reduce calcium thus reduce vitamin D which if you're looking at
 
 00:02:57.200 --> 00:03:02.720
- through that lens that would make sense. However in the bioengine in your viewpoint or pro metabolic
+ through that lens that would make sense. However in the bioengine, in your viewpoint or pro metabolic
 
 00:03:02.720 --> 00:03:08.480
  view we see calcium quite differently and we see calcium is very metabolic and if somebody
@@ -118,7 +118,7 @@ WEBVTT
  and I was just telling him how much awesome feedback we got from that and it's the most
 
 00:04:03.920 --> 00:04:08.400
- downloaded podcast we have on the Win It Life podcast and everyone was saying the information
+ downloaded podcast we have on the Win At Life podcast and everyone was saying the information
 
 00:04:08.400 --> 00:04:15.280
  was just so valuable and it was really easy to understand. So yeah Dr. Peat thanks so much for
@@ -241,7 +241,7 @@ WEBVTT
  to the production of vitamin D? No the cave fish seems to illustrate that the the organism doesn't
 
 00:09:46.880 --> 00:09:56.880
- really need a vitamin D if it has lots of calcium and experiments with various trash and sea water
+ really need a vitamin D if it has lots of calcium and experiments with various fresh and sea water
 
 00:09:56.880 --> 00:10:11.440
  fish show that they have a very limited need for it. The abundance of calcium has made them handle
@@ -319,7 +319,7 @@ WEBVTT
  and so they produced the same material exactly that that fish produced by being in the sunlight
 
 00:13:58.880 --> 00:14:04.720
- or by eating that algae that was in the sunlight or zoa plankton that was in the sunlight.
+ or by eating that algae that was in the sunlight or zooplankton that was in the sunlight.
 
 00:14:05.440 --> 00:14:10.640
  Okay so you're saying that any animal or meat or food product that is actually getting sunlight
@@ -340,7 +340,7 @@ WEBVTT
  have called the storage form of vitamin D but that doesn't really mean much except that the liver
 
 00:14:57.600 --> 00:15:10.720
- does bind enough of the 25 hydroxy choleciferol to last for a few months and some of it is bound
+ does bind enough of the 25-hydroxycholecalciferol to last for a few months and some of it is bound
 
 00:15:10.720 --> 00:15:23.200
  on proteins such as calbindin or the calcium binding protein and it passively dissolves
@@ -355,13 +355,13 @@ WEBVTT
  amount is stored in your fat tissues besides what's in your liver and that conversion
 
 00:15:55.120 --> 00:16:00.080
- to the hydroxy cholecalciferol that happens in the liver
+ to the hydroxycholecalciferol that happens in the liver
 
 00:16:00.080 --> 00:16:10.480
  can be blocked by a liver problem so a person with a sick liver is going to have
 
 00:16:10.480 --> 00:16:23.520
- probably enough of the plain cholecalciferol but have a very low level of the 25 hydroxy cholecalciferol
+ probably enough of the plain cholecalciferol but have a very low level of the 25-hydroxycholecalciferol
 
 00:16:24.400 --> 00:16:34.320
  and when you're low very low in that form of the half activated vitamin D
@@ -370,16 +370,16 @@ WEBVTT
  especially if your calcium intake is limited then you will activate your kidneys
 
 00:16:45.680 --> 00:16:57.360
- the traditional story goes that under stress at efficiency of either 25 hydroxy cholecalciferol
+ the traditional story goes that under stress at efficiency of either 25-hydroxycholecalciferol
 
 00:16:57.360 --> 00:17:12.800
- or calcium will cause your liver your kidneys to produce one hydroxy 125 dihydroxy cholecalciferol
+ or calcium will cause your liver your kidneys to produce 1,25-dihydroxycholecalciferol
 
 00:17:13.760 --> 00:17:26.720
  activating the one hydroxylase enzyme in your kidneys but in actuality any inflamed or stressed
 
 00:17:26.720 --> 00:17:36.800
- tissue has that ability to make one comma 25 dihydroxy cholecalciferol the old textbooks
+ tissue has that ability to make 1,25-dihydroxycholecalciferol the old textbooks
 
 00:17:36.800 --> 00:17:43.920
  say it happens only in the kidneys but actually any stress tissue seems to be able to do it
@@ -388,7 +388,7 @@ WEBVTT
  cancer cells for example are very good at the one hydroxylation which makes the so-called
 
 00:17:53.680 --> 00:18:02.880
- active vitamin D okay so i'm gonna i'm gonna wind it back a second because that was a lot of
+ active vitamin D okay so I'm gonna I'm gonna wind it back a second because that was a lot of
 
 00:18:02.880 --> 00:18:08.560
  information just kind of try to summarize it so that people can kind of understand and because
@@ -397,19 +397,19 @@ WEBVTT
  there's so much terminology as we know in the in the D world there is obviously D3 or cholecalciferol
 
 00:18:15.440 --> 00:18:21.840
- which is the the starting supplementation form and then it does get converted into the 25 OHD
+ which is the the starting supplementation form and then it does get converted into the 25-OHD
 
 00:18:21.840 --> 00:18:28.080
  or the calcium the calcium were what they refer to as stored and maybe that we'll use that term
 
 00:18:28.080 --> 00:18:32.080
- if that's okay because i think that's probably easiest to understand it doesn't mean that that's
+ if that's okay because I think that's probably easiest to understand it doesn't mean that that's
 
 00:18:32.080 --> 00:18:37.840
  it's only form but that's what it's kind of known in in the language and then it does convert into
 
 00:18:37.840 --> 00:18:45.840
- the active D and i think what you kind of just explained was that the stored D converts into the
+ the active D and I think what you kind of just explained was that the stored D converts into the
 
 00:18:45.840 --> 00:18:52.240
  active D under stress it's not that that is the active form is what is where the active metabolites
@@ -418,10 +418,10 @@ WEBVTT
  and all the good stuff is it's that it actually converts when the tissue or when the system is
 
 00:18:58.400 --> 00:19:08.400
- under stress is that correct yeah i think it's the situation between cholecalciferol or the 25
+ under stress is that correct yeah I think it's the situation between cholecalciferol or the 25
 
 00:19:08.400 --> 00:19:18.880
- hydroxy form and the 125 dihydroxy the relationship is very analogous to what happens when your thyroid
+ hydroxy form and the 1,25-dihydroxy the relationship is very analogous to what happens when your thyroid
 
 00:19:18.880 --> 00:19:27.920
  is low your actual thyroid hormone your body increases the TSH thyroid stimulating hormone
@@ -445,13 +445,13 @@ WEBVTT
  body goes into an emergency reaction in which it at the same time that it's trying to correct
 
 00:20:29.520 --> 00:20:42.320
- the deficiency it's turning on a substance such as 125 dihydroxy D or luteinizing hormone
+ the deficiency it's turning on a substance such as 1,25-dihydroxy D or luteinizing hormone
 
 00:20:42.320 --> 00:20:49.360
  or thyroid stimulating hormone which in the process of adjusting has lots of dangerous
 
 00:20:50.000 --> 00:21:03.040
- toxic side effects in the case of 125 hydroxy G these unwanted side effects include obesity
+ toxic side effects in the case of 1,25-hydroxy D these unwanted side effects include obesity
 
 00:21:03.040 --> 00:21:14.800
  and osteoporosis for example when the conditions are stressful enough your parathyroid hormone
@@ -460,10 +460,10 @@ WEBVTT
  increases and it's the major signal for turning on the one hydroxylase enzyme
 
 00:21:24.080 --> 00:21:34.400
- that so-called activates the vitamin B and when you're dominated by parathyroid hormone
+ that so-called activates the vitamin D and when you're dominated by parathyroid hormone
 
 00:21:35.120 --> 00:21:46.400
- and the consequential 125 dihydroxy D then you start breaking down your bones and turning off
+ and the consequential 1,25-dihydroxy D then you start breaking down your bones and turning off
 
 00:21:46.400 --> 00:21:54.560
  your oxidative metabolism blocking the electron transport chain and creating the conditions for
@@ -475,19 +475,19 @@ WEBVTT
  creating fat tissue and storing energy and all of the emergency things are activated
 
 00:22:17.360 --> 00:22:26.160
- bites the stress or inflammation that leads to turning on parathyroid hormone and the main
+ by the stress or inflammation that leads to turning on parathyroid hormone and the main
 
 00:22:26.160 --> 00:22:34.560
  two things that will keep your parathyroid hormone down and under control and stop all of those
 
 00:22:34.560 --> 00:22:46.720
- degenerative processes the main things are calcium and vitamin D the 25 hydroxy form
+ degenerative processes the main things are calcium and vitamin D the 25-hydroxy form
 
 00:22:46.720 --> 00:22:53.760
- okay so essentially what you're saying is the 125 or the active form as a lot of people call it
+ okay so essentially what you're saying is the 1,25 or the active form as a lot of people call it
 
 00:22:53.760 --> 00:23:00.560
- D is basically prone and it gives all the inflammatory at high levels of 125 D are not
+ D is basically prone and it gives all the inflammatory at high levels of 1,25 D are not
 
 00:23:00.560 --> 00:23:05.440
  good and that's when you get a lot of the inflammatory responses weight gain elevated
@@ -511,13 +511,13 @@ WEBVTT
  and again turns on all of those pro-inflammatory processes so essentially keeping the body out of
 
 00:23:54.080 --> 00:24:01.520
- stress and so the elevated 125 D is just a one of the many responses your body can adjust to when
+ stress and so the elevated 1,25 D is just a one of the many responses your body can adjust to when
 
 00:24:01.520 --> 00:24:09.200
  under stress and that would gotcha okay and so that's just the first question so we could be
 
 00:24:09.200 --> 00:24:16.880
- here for four days um that was super awesome and helpful and i'll and it kind of kind of goes into
+ here for four days um that was super awesome and helpful and I'll and it kind of kind of goes into
 
 00:24:16.880 --> 00:24:23.520
  this next question is uh how is getting vitamin D from sunlight different from getting it from a
@@ -532,13 +532,13 @@ WEBVTT
  you get other good effects from the sunlight but basically as far as the vitamin D is concerned
 
 00:24:40.000 --> 00:24:50.400
- i i think they function identically along with the sunlight you're getting visible light
+ I I think they function identically along with the sunlight you're getting visible light
 
 00:24:50.400 --> 00:24:58.160
  which is another thing that activates oxidative metabolism in support of the good kind of vitamin
 
 00:24:58.160 --> 00:25:05.600
- D gotcha so there obviously there's a lot of other benefits of the sunlight i guess one of
+ D gotcha so there obviously there's a lot of other benefits of the sunlight I guess one of
 
 00:25:05.600 --> 00:25:11.520
  the things is that we know that usually most people can't they won't overdose on D by getting
@@ -559,7 +559,7 @@ WEBVTT
  nearly as much what when you're when you have enough of the colecalciferol
 
 00:25:47.440 --> 00:25:57.200
- in your tissues it's like a radiation resistance factor okay so for somebody that as i mean i
+ in your tissues it's like a radiation resistance factor okay so for somebody that as I mean I
 
 00:25:57.200 --> 00:26:01.360
  definitely have people say that they no longer can tan any longer then when they go out into
@@ -568,19 +568,19 @@ WEBVTT
  the sun they just burn so would that be a sign that they are low D yeah for most of my life
 
 00:26:09.680 --> 00:26:19.680
- i would sunburn very very easily just driving in a closed car through a bright landscape
+ I would sunburn very very easily just driving in a closed car through a bright landscape
 
 00:26:19.680 --> 00:26:28.800
- my face would get bright red and i would have a shiny red nose from just a few hours of exposure
+ my face would get bright red and I would have a shiny red nose from just a few hours of exposure
 
 00:26:28.800 --> 00:26:36.400
  sideways through the windows of a car and that isn't a very big dose of
 
 00:26:36.400 --> 00:26:43.440
- ultraviolet but i was super sensitive to it and after i started supplementing vitamin D
+ ultraviolet but I was super sensitive to it and after I started supplementing vitamin D
 
 00:26:43.440 --> 00:26:51.280
- i could spend hours outside in mexico at an altitude of seven or eight thousand feet
+ I could spend hours outside in mexico at an altitude of seven or eight thousand feet
 
 00:26:51.280 --> 00:27:01.120
  super intense radiation and not even get a red nose and why do you think that is why do you think
@@ -589,7 +589,7 @@ WEBVTT
  that you were not able to get the needed sun or the vitamin D from the sun where that would help
 
 00:27:06.080 --> 00:27:15.440
- build up the the supplementation is what worked for you i just didn't uh apparently stay in the
+ build up the the supplementation is what worked for you I just didn't uh apparently stay in the
 
 00:27:15.440 --> 00:27:25.840
  sun long enough gradually enough once you get the protective level of a vitamin D up then it's easy
@@ -601,7 +601,7 @@ WEBVTT
  anti-stress effects but once once you're deficient the fact that you sunburn so easily
 
 00:27:44.240 --> 00:27:51.120
- attempts to make you avoid the sunlight i see so it's essentially like everything else in this
+ attempts to make you avoid the sunlight I see so it's essentially like everything else in this
 
 00:27:51.120 --> 00:27:56.000
  planet that you need to build up so it's a training mechanism to build up your vitamin D
@@ -613,19 +613,19 @@ WEBVTT
  would work it would be just as effective than actually having a supplementation yeah okay um
 
 00:28:08.400 --> 00:28:15.840
- i want to go back to when you were talking about the the 25d or the the calcideal also known as a
+ I want to go back to when you were talking about the the 25D or the the calcifediol also known as a
 
 00:28:15.840 --> 00:28:22.240
- store d and i think in in a lot of the other communities that talk about it they they say it
+ stored D and I think in in a lot of the other communities that talk about it they they say it
 
 00:28:22.240 --> 00:28:28.880
  is an inactive form and that this inactive form just can't have any sort of response in our system
 
 00:28:28.880 --> 00:28:34.880
- that it's only the 125d that actually has the any sort of response and i know you certainly told
+ that it's only the 1,25-D that actually has the any sort of response and I know you certainly told
 
 00:28:34.880 --> 00:28:40.240
- me that the the calcideal or the store d does actually have active form and that's the one
+ me that the the calcifediol or the store D does actually have active form and that's the one
 
 00:28:40.240 --> 00:28:45.040
  that actually produces all the good stuff in our body can you give us a little more detail about
@@ -634,22 +634,22 @@ WEBVTT
  that yeah the decisive experiments that show that were the receptor knockout experiments
 
 00:28:54.640 --> 00:29:06.880
- the vitamin D receptor supposedly responds to the d1 25 dihydroxy but if you knock out
+ the vitamin D receptor supposedly responds to the 1,25-dihydroxy but if you knock out
 
 00:29:07.760 --> 00:29:17.520
- that receptor the 25 hydroxy does all of the same functions so neither the receptor nor the 125
+ that receptor the 25-hydroxy does all of the same functions so neither the receptor nor the 1,25-dihydroxy
 
 00:29:17.520 --> 00:29:27.520
- dihydroxy is essential when you have calcium and the 25 hydroxy and and their knockout
+ is essential when you have calcium and the 25-hydroxy and and their knockout
 
 00:29:27.520 --> 00:29:38.400
  experiments with the one hydroxylase two similar results so that kind of goes back to Gilbert
 
 00:29:38.400 --> 00:29:44.480
- Ling's theory that that it's not just about this receptor idea and i know they kind of talk a lot
+ Ling's theory that that it's not just about this receptor idea and I know they kind of talk a lot
 
 00:29:44.480 --> 00:29:51.280
- about the ddr the the vitamin D receptors in the um anti-desupliment group and and essentially what
+ about the VDR the the vitamin D receptors in the um anti-D-supplement group and and essentially what
 
 00:29:51.280 --> 00:29:59.920
  you're saying is that that doesn't matter yeah the whole cell the whole organism in fact is the real
@@ -682,7 +682,7 @@ WEBVTT
  other things take take over and fill in for the lack of that particular thing
 
 00:31:16.240 --> 00:31:26.000
- i see okay so i guess just for context it's it's good to know that the the cell will respond
+ I see okay so I guess just for context it's it's good to know that the the cell will respond
 
 00:31:26.000 --> 00:31:30.320
  differently depending on the environment that it's in and if the body is healthier it's going to
@@ -706,7 +706,7 @@ WEBVTT
  the cell is more oriented and ready to handle its environment when the whole system
 
 00:32:13.520 --> 00:32:23.360
- is well energized and well fed gotcha so what about the belief that a vitamin d supplement
+ is well energized and well fed gotcha so what about the belief that a vitamin D supplement
 
 00:32:23.360 --> 00:32:29.200
  is actually immune suppressive so some people report that they feel better taking a vitamin
@@ -715,13 +715,13 @@ WEBVTT
  d supplement and then one theory is that well the reason you feel better is is because it is
 
 00:32:34.720 --> 00:32:42.080
- suppressing your immune system is what's happening is it's just suppressing the 125d and and that's
+ suppressing your immune system is what's happening is it's just suppressing the 1-25d and and that's
 
 00:32:42.080 --> 00:32:52.480
- what's making you feel better i i think that's part of it part of the confusion is the definition
+ what's making you feel better I i think that's part of it part of the confusion is the definition
 
 00:32:52.480 --> 00:33:00.720
- of the immune system people talk about wanting to stimulate the immune system but i think that's
+ of the immune system people talk about wanting to stimulate the immune system but I think that's
 
 00:33:00.720 --> 00:33:12.480
  the last thing we we want to do the immune system it means whatever we do to a damaging
@@ -730,7 +730,7 @@ WEBVTT
  threat some kind of the injury then we say that the immune system has been activated
 
 00:33:21.840 --> 00:33:28.240
- but a very healthy organism for example with lots of calcium and vitamin d
+ but a very healthy organism for example with lots of calcium and vitamin D
 
 00:33:28.240 --> 00:33:35.360
  doesn't even notice it isn't harmed by the presence of the pathogen
@@ -754,10 +754,10 @@ WEBVTT
  or a toxin and so on the body doesn't get damaged when it's in a healthy energized condition
 
 00:34:34.960 --> 00:34:43.200
- right so i'm going to take a little turn and and say there are some researchers that are utilizing
+ right so I'm going to take a little turn and and say there are some researchers that are utilizing
 
 00:34:43.200 --> 00:34:51.040
- like a really low vitamin d status to address autoimmune issues and they're saying that if
+ like a really low vitamin D status to address autoimmune issues and they're saying that if
 
 00:34:51.040 --> 00:34:58.400
  they suppress the d status to well below 12 that they're actually getting responses where people
@@ -766,10 +766,10 @@ WEBVTT
  are recovering from an autoimmune issue is there some explanation for that that would be the
 
 00:35:05.200 --> 00:35:08.960
- trevor marshall people that would be them correct
+ Trevor Marshall people that would be them correct
 
 00:35:08.960 --> 00:35:23.120
- the i don't like to even call it reasoning it's the application of an engineering
+ the I don't like to even call it reasoning it's the application of an engineering
 
 00:35:23.920 --> 00:35:33.200
  metaphor to biology and an electrical engineer for example thinks in terms of hard wiring
@@ -781,52 +781,52 @@ WEBVTT
  and the innate immune processes and all of that fits very well with
 
 00:35:53.920 --> 00:36:02.800
- an engineering orientation and a lot of if not all of trevor marshall's
+ an engineering orientation and a lot of if not all of Trevor Marshall's
 
 00:36:04.000 --> 00:36:14.160
  ideas are based on what he calls computer modeling and in 2006 he referred to the
 
 00:36:14.160 --> 00:36:22.160
- omysartan and similar angiotensin receptor inhibitors
+ Olmesartan and similar angiotensin receptor inhibitors
 
 00:36:24.240 --> 00:36:34.960
- called them antagonists of the vitamin d receptor but then in 2017 he was calling them agonists of
+ called them antagonists of the vitamin D receptor but then in 2017 he was calling them agonists of
 
 00:36:34.960 --> 00:36:44.240
- the vitamin d receptor and saying they restored the vitamin d receptor function and what they
+ the vitamin D receptor and saying they restored the vitamin D receptor function and what they
 
 00:36:44.240 --> 00:36:53.520
  empirically are doing with a mild dose of minocycline it happens to be a very effective
 
 00:36:53.520 --> 00:37:04.800
- anti-inflammatory agent as well as an antibiotic or antibacterial and the sartans only sartan or
+ anti-inflammatory agent as well as an antibiotic or antibacterial and the sartans, olmesartan or
 
 00:37:04.800 --> 00:37:14.960
- low sartan those are very basic effective anti-inflammatory agents and so when you're
+ losartan those are very basic effective anti-inflammatory agents and so when you're
 
 00:37:14.960 --> 00:37:23.600
  talking about autoimmune and degenerative diseases both anti-inflammatory agents
 
 00:37:23.600 --> 00:37:30.240
- minocycline and omysartan are going to reduce the symptoms and
+ minocycline and olmesartan are going to reduce the symptoms and
 
 00:37:33.760 --> 00:37:42.960
- i don't think they have any particular either antagonist or receptive or a restorative effect
+ I don't think they have any particular either antagonist or receptive or a restorative effect
 
 00:37:42.960 --> 00:37:50.960
- on the vitamin d receptor so so yeah trevor marshall uses i think it's venicar to treat
+ on the vitamin D receptor so so yeah Trevor Marshall uses I think it's venicar to treat
 
 00:37:50.960 --> 00:37:58.480
  a lot of his patients which is a angiotensin 2 receptor antagonist blood pressure medication but
 
 00:37:58.480 --> 00:38:04.640
- what you're saying is that it may be not even the the suppression of vitamin d that's making
+ what you're saying is that it may be not even the the suppression of vitamin D that's making
 
 00:38:04.640 --> 00:38:10.800
- the difference it might just be these medications are making the difference yeah i don't think he
+ the difference it might just be these medications are making the difference yeah I don't think he
 
 00:38:10.800 --> 00:38:20.000
- presents any evidence at all that it has anything to do with the vitamin d receptor it was originally
+ presents any evidence at all that it has anything to do with the vitamin D receptor it was originally
 
 00:38:20.000 --> 00:38:31.920
  based on so-called computer modeling no experiments really and and then he changed his from antagonist
@@ -838,10 +838,10 @@ WEBVTT
  agents regardless of whether it's rheumatoid arthritis that's the problem or covid infection
 
 00:38:53.920 --> 00:39:04.320
- it's a general all-purpose anti-inflammatory protective substance right i remember you talking
+ it's a general all-purpose anti-inflammatory protective substance right I remember you talking
 
 00:39:04.320 --> 00:39:11.120
- about low sartan being used in in covid and helped people get through covid so i would imagine that
+ about losartan being used in in covid and helped people get through covid so I would imagine that
 
 00:39:11.120 --> 00:39:19.360
  these other ones would work as well very interesting um okay so flipping again could
@@ -856,25 +856,25 @@ WEBVTT
  sign that they may be sick and that restoring their health would correct their d
 
 00:39:43.680 --> 00:39:56.400
- um if a person is taking large amounts of a vitamin d supplement and or getting sunlight
+ um if a person is taking large amounts of a vitamin D supplement and or getting sunlight
 
 00:39:57.040 --> 00:40:08.160
- and still they're circulating uh 25 hydroxy cholecalciferol if that is still low i think that
+ and still they're circulating uh 25-hydroxycholecalciferol if that is still low I think that
 
 00:40:08.160 --> 00:40:16.400
  means they have a liver inflammatory problem because the liver is a major part that creates
 
 00:40:16.400 --> 00:40:25.360
- the 25 hydroxy active form but i i think most of the background of the question has to do with the
+ the 25 hydroxy active form but I i think most of the background of the question has to do with the
 
 00:40:26.160 --> 00:40:34.720
- trevor marshall's doctrine that there are occult organisms inside cells causing sickness
+ Trevor Marshall's doctrine that there are occult organisms inside cells causing sickness
 
 00:40:34.720 --> 00:40:45.280
  and that his protocol is the way to eventually eliminate those occult organisms
 
 00:40:45.280 --> 00:40:54.880
- so let's say somebody was taking a decent amount of d of getting sunlight and had like i said low
+ so let's say somebody was taking a decent amount of d of getting sunlight and had like I said low
 
 00:40:54.880 --> 00:41:00.480
  d level still their store d was quite low what would you at that point recommend would you say
@@ -886,19 +886,19 @@ WEBVTT
  yeah the whole picture of what could be the source of inflammation and liver injury
 
 00:41:12.480 --> 00:41:19.440
- but taking vitamin d isn't going to make the problem worse the way the
+ but taking vitamin D isn't going to make the problem worse the way the
 
 00:41:20.160 --> 00:41:29.840
- trevor people marshall people say it will okay so at that point what about for somebody who takes
+ Trevor people Marshall people say it will okay so at that point what about for somebody who takes
 
 00:41:29.840 --> 00:41:39.920
- a d supplement and it makes them feel absolutely horrible what would happen i've been hearing from
+ a d supplement and it makes them feel absolutely horrible what would happen I've been hearing from
 
 00:41:39.920 --> 00:41:49.200
  a few people who were deteriorating rapidly one thought she was approaching death with
 
 00:41:49.200 --> 00:41:59.280
- neurological and all kinds of other symptoms and i looked at her diet and supplements and she was
+ neurological and all kinds of other symptoms and I looked at her diet and supplements and she was
 
 00:41:59.280 --> 00:42:07.440
  supplementing things in a base of medium chain triglycerides and when she stopped everything
@@ -916,7 +916,7 @@ WEBVTT
  andogens and allergens and makes us susceptible to food allergy symptoms
 
 00:42:46.160 --> 00:42:55.280
- that's interesting i mean the one supplement i usually recommend is carlson's and that is in mct
+ that's interesting I mean the one supplement I usually recommend is carlson's and that is in mct
 
 00:42:55.280 --> 00:43:02.960
  oil so you are saying to avoid the ones in mct oil or if it's if it is creating an irritation
@@ -925,40 +925,40 @@ WEBVTT
  it could be the oil might might be okay are they okay to have in mct oil is there one that you
 
 00:43:08.160 --> 00:43:15.360
- know of that is good that is not in those things a lot of people get benefit from them but i think
+ know of that is good that is not in those things a lot of people get benefit from them but I think
 
 00:43:16.080 --> 00:43:26.720
- some of the intense bad reactions stop happening when they use a olive oil at base vitamin d
+ some of the intense bad reactions stop happening when they use a olive oil at base vitamin D
 
 00:43:26.720 --> 00:43:32.480
- there are several companies that that make a pure olive oil and vitamin d
+ there are several companies that that make a pure olive oil and vitamin D
 
 00:43:32.480 --> 00:43:39.920
  product either in drops or capsules okay do you happen to know any offhand that we don't remember
 
 00:43:40.960 --> 00:43:48.880
- no i don't remember just look for the price at that very tremendously in in cost so a vitamin d
+ no I don't remember just look for the price at that very tremendously in in cost so a vitamin D
 
 00:43:48.880 --> 00:43:55.040
  in olive oil would would be where to try if if you are currently taking a d supplement and having a
 
 00:43:55.040 --> 00:44:06.080
- bad reaction and i think so lead at low d status okay um what about let's kind of flip into maybe
+ bad reaction and I think so lead at low d status okay um what about let's kind of flip into maybe
 
 00:44:06.080 --> 00:44:12.560
  talking a little about the calcium and d um kind of communication and how they're all intertwined
 
 00:44:12.560 --> 00:44:25.280
- with each other and so well i'm gonna go back real quick um if somebody has low d could it also mean
+ with each other and so well I'm gonna go back real quick um if somebody has low d could it also mean
 
 00:44:25.280 --> 00:44:31.680
- other things meaning i certainly read some research showing that just taking magnesium
+ other things meaning I certainly read some research showing that just taking magnesium
 
 00:44:31.680 --> 00:44:40.480
  can raise store d levels so it would it make sense for someone to actually explore other avenues
 
 00:44:40.480 --> 00:44:48.560
- before taking a d supplement like looking at some of the co-factors that go into vitamin d metabolism
+ before taking a d supplement like looking at some of the co-factors that go into vitamin D metabolism
 
 00:44:48.560 --> 00:44:59.840
  yeah for example including milk and cheese in your diet is a good first step to to see whether it
@@ -985,16 +985,16 @@ WEBVTT
  is that correct yeah okay okay so our here's an interesting question are high cholesterol levels
 
 00:46:04.000 --> 00:46:11.920
- and low vitamin d status correlated since cholesterol is the precursor for d yeah in
+ and low vitamin D status correlated since cholesterol is the precursor for d yeah in
 
 00:46:11.920 --> 00:46:22.800
- old people for example the vitamin d that is active in the skin is greatly reduced
+ old people for example the vitamin D that is active in the skin is greatly reduced
 
 00:46:22.800 --> 00:46:30.480
  and that shows that the cholesterol
 
 00:46:30.480 --> 00:46:41.040
- is a major reason that aging reduces vitamin d production they just aren't putting the
+ is a major reason that aging reduces vitamin D production they just aren't putting the
 
 00:46:41.040 --> 00:46:45.520
  cholesterol in the position to be activated by sunlight
@@ -1003,10 +1003,10 @@ WEBVTT
  so then it would be fair to say that possibly taking a statin or any cholesterol
 
 00:46:53.920 --> 00:46:56.880
- lowering medication is certainly going to affect your vitamin d status
+ lowering medication is certainly going to affect your vitamin D status
 
 00:46:56.880 --> 00:47:05.200
- yeah it affects everything including vitamin d status okay so that would be certainly something
+ yeah it affects everything including vitamin D status okay so that would be certainly something
 
 00:47:05.200 --> 00:47:10.400
  to look at would it be more something if your cholesterol was high would it would you first
@@ -1036,10 +1036,10 @@ WEBVTT
  de-stressing that alone without even taking a d supplement could improve their d status
 
 00:48:24.640 --> 00:48:37.280
- yeah the thyroid and vitamin d and calcium are intimately interrelated you can't separate
+ yeah the thyroid and vitamin D and calcium are intimately interrelated you can't separate
 
 00:48:37.280 --> 00:48:47.680
- the thyroid from the vitamin d and calcium metabolism gotcha okay um what about can we
+ the thyroid from the vitamin D and calcium metabolism gotcha okay um what about can we
 
 00:48:47.680 --> 00:48:53.840
  actually store enough d for the winter months is is that what the summer is all about and
@@ -1054,7 +1054,7 @@ WEBVTT
  the winter or for those people is it pretty evident that they'll need to be taking some
 
 00:49:08.640 --> 00:49:13.920
- sort of supplementation or certainly eating foods that are certainly high in vitamin d
+ sort of supplementation or certainly eating foods that are certainly high in vitamin D
 
 00:49:15.040 --> 00:49:22.880
  if they have really been in the sun during the summer they will assuming that their liver is
@@ -1069,16 +1069,16 @@ WEBVTT
  and also how good their thyroid status is and their general metabolism but yes
 
 00:49:46.160 --> 00:49:56.640
- the reason eating fish liver or beef liver or whatever is a good source of vitamin d
+ the reason eating fish liver or beef liver or whatever is a good source of vitamin D
 
 00:49:56.640 --> 00:50:02.800
- is that the liver does store a considerable amount of vitamin d
+ is that the liver does store a considerable amount of vitamin D
 
 00:50:04.640 --> 00:50:11.120
- okay so kind of getting on that so would you and i know you've gone um and said kind of good
+ okay so kind of getting on that so would you and I know you've gone um and said kind of good
 
 00:50:11.120 --> 00:50:17.680
- and bad so would you say that cod liver oil would be an okay way to supplement vitamin d
+ and bad so would you say that cod liver oil would be an okay way to supplement vitamin D
 
 00:50:17.680 --> 00:50:29.280
  except that it comes with a considerable amount of fish oil yes and fish oil over time
@@ -1087,22 +1087,22 @@ WEBVTT
  tends to accumulate with pro estrogen effects pro inflammatory pro aging anti thyroid effects
 
 00:50:39.760 --> 00:50:47.840
- so i don't think it's the best way to get your vitamin d and vitamin a but it is a
+ so I don't think it's the best way to get your vitamin D and vitamin A but it is a
 
 00:50:47.840 --> 00:50:57.760
- source in an emergency better to use cod liver oils and to be deficient in vitamin d
+ source in an emergency better to use cod liver oils and to be deficient in vitamin D
 
 00:50:58.720 --> 00:51:05.760
  right but something like beef liver or whole milk would be better options much much better
 
 00:51:05.760 --> 00:51:13.680
- okay and what about let's say milk that has been fortified with vitamin d is that safe
+ okay and what about let's say milk that has been fortified with vitamin D is that safe
 
 00:51:13.680 --> 00:51:25.760
- the choice of emulsifiers i'm not sure how much latitude there is but i've heard that
+ the choice of emulsifiers I'm not sure how much latitude there is but I've heard that
 
 00:51:26.320 --> 00:51:36.000
- polysorbate 80 and polyethylene glycol have been used as emulsifiers for the vitamin a and vitamin d
+ polysorbate 80 and polyethylene glycol have been used as emulsifiers for the vitamin A and vitamin D
 
 00:51:36.000 --> 00:51:43.760
  and since some people are very allergic to those polymers you have to
@@ -1117,64 +1117,64 @@ WEBVTT
  to reduce the very high fat content of the whole milk and get an unadulterated natural milk
 
 00:52:13.520 --> 00:52:19.760
- right and that's one thing i certainly remember i mean over in the states we know that all low fat
+ right and that's one thing I certainly remember I mean over in the states we know that all low fat
 
 00:52:19.760 --> 00:52:26.960
- milk is has additives of a and d in it i don't think there are any that don't that are low fat
+ milk is has additives of A and D in it I don't think there are any that don't that are low fat
 
 00:52:26.960 --> 00:52:32.800
- and i know you consume a lower fat milk and i usually consume a milk like straws where you can
+ and I know you consume a lower fat milk and I usually consume a milk like straws where you can
 
 00:52:32.800 --> 00:52:39.040
- actually skim the fat now if i was a skim the fat aren't i removing a lot of the a and the d that
+ actually skim the fat now if I was to skim the fat aren't I removing a lot of the A and the D that
 
 00:52:39.040 --> 00:52:48.480
- i'm trying to get yeah but a moderate amount like one or two percent fat is all you need for the
+ I'm trying to get yeah but a moderate amount like one or two percent fat is all you need for the
 
 00:52:48.480 --> 00:52:55.440
- vitamins if the cows are healthy okay okay and then you i know you use a lower fat milk do you
+ vitamins if the cows are healthy okay okay and then you I know you use a lower fat milk do you
 
 00:52:55.440 --> 00:53:02.880
- have a brand that you prefer that seems to do okay for you uh no i just get whatever tastes good
+ have a brand that you prefer that seems to do okay for you uh no I just get whatever tastes good
 
 00:53:02.880 --> 00:53:12.080
  some of the organic milks have a really bad taste and that means their cows were eating
 
 00:53:12.640 --> 00:53:21.680
- some kind of odd weeds that i don't like so i go by the taste okay so the so does your grocery
+ some kind of odd weeds that I don't like so I go by the taste okay so the so does your grocery
 
 00:53:21.680 --> 00:53:26.080
  store kind of let you taste test when that would be nice if we could all like you know it like going
 
 00:53:26.080 --> 00:53:32.960
- to a winery you could taste your milk before you purchased it that would be nice but i just don't
+ to a winery you could taste your milk before you purchased it that would be nice but I just don't
 
 00:53:32.960 --> 00:53:39.680
- buy it again when it tastes too bad that's probably good advice katie what do you do for your milk are
+ buy it again when it tastes too bad that's probably good advice Kitty what do you do for your milk are
 
 00:53:39.680 --> 00:53:46.480
- you are you still there i am still here i um we drink low-fat milk craig likes skim milk because
+ you are you still there I am still here I um we drink low-fat milk Craig likes skim milk because
 
 00:53:46.480 --> 00:53:51.040
- he drink i think skim is what the equivalent because you guys call it different things
+ he drink I think skim is what the equivalent because you guys call it different things
 
 00:53:51.040 --> 00:53:57.120
  we call it low-fat yes you've got one percent and then yeah he drinks the like the really low fat
 
 00:53:57.120 --> 00:54:00.960
- lungs he drinks loads of milk i drink the low fat but we're so lucky over here we don't they're not
+ loads he drinks loads of milk I drink the low fat but we're so lucky over here we don't they're not
 
 00:54:00.960 --> 00:54:06.720
  fortified with vitamins which is so awesome so yeah we just get them from our there's a couple
 
 00:54:06.720 --> 00:54:14.320
- of local um dairies that we support that we get our milk from um which is really good but yeah i
+ of local um dairies that we support that we get our milk from um which is really good but yeah I
 
 00:54:14.320 --> 00:54:18.160
  really feel for all our american and overseas clients because they're always posting about how
 
 00:54:18.160 --> 00:54:25.200
- they just can't find milk low-fat milk without the added vitamins yeah so i think the takeaway is
+ they just can't find milk low-fat milk without the added vitamins yeah so I think the takeaway is
 
 00:54:25.200 --> 00:54:30.640
  yet you know you can either buy a milk that's full and try to skim the fat or you know try other ones
@@ -1183,28 +1183,28 @@ WEBVTT
  and if they taste good you know and and you don't have some sort of reaction to it then it's a good
 
 00:54:34.720 --> 00:54:39.760
- milk but some people i find when reintroducing milk that whole seems to be the easiest route
+ milk but some people I find when reintroducing milk that whole seems to be the easiest route
 
 00:54:39.760 --> 00:54:44.480
  because they seem to tolerate the best at least in the beginning so um that's my general advice on
 
 00:54:44.480 --> 00:54:56.560
- that okay uh still got a bunch so everybody put on their seat belt um so ray when we measure the
+ that okay uh still got a bunch so everybody put on their seat belt um so Ray when we measure the
 
 00:54:56.560 --> 00:55:04.640
- stored vitamin d or the calcidil uh in the blood is is this an accurate number because i always hear
+ stored vitamin D or the calcidiol uh in the blood is is this an accurate number because I always hear
 
 00:55:04.640 --> 00:55:09.440
  about there's certain things like estrogen and iron that you know really doesn't matter what's
 
 00:55:09.440 --> 00:55:14.880
- in the blood it's because it's in the tissue is this a similar case for store d because there
+ in the blood it's because it's in the tissue is this a similar case for stored D because there
 
 00:55:14.880 --> 00:55:24.640
  obviously is a lot in the tissue as well um uh no the circulating in the blood you have the
 
 00:55:25.440 --> 00:55:36.000
- vitamin g binding protein as well as the lipids in the blood that are carrying a large amount of it
+ vitamin D binding protein as well as the lipids in the blood that are carrying a large amount of it
 
 00:55:36.000 --> 00:55:52.320
  so it the fat tissues passively act as storage but at a level not much higher than in the blood
@@ -1216,13 +1216,13 @@ WEBVTT
  vital tissues to see how much of the 25 hydroxy is inside the cells it's assumed that the cells will
 
 00:56:22.000 --> 00:56:31.440
- take up according to what they need probably very similar to the blood level i see i think
+ take up according to what they need probably very similar to the blood level I see I think
 
 00:56:31.440 --> 00:56:37.120
  you once told me that if you are have a good amount of body fat on you though won't your body
 
 00:56:37.120 --> 00:56:44.400
- store more of that d in the tissue so maybe your numbers won't be as high and that might also be to
+ store more of that D in the tissue so maybe your numbers won't be as high and that might also be to
 
 00:56:44.400 --> 00:56:53.840
  due to a liver issue the level in the fat tissue corresponds pretty closely to the concentration
@@ -1231,34 +1231,34 @@ WEBVTT
  in the blood so if you have a very big volume of fat tissue at that same concentration then yeah
 
 00:57:01.360 --> 00:57:11.840
- that will act as a storage supplementing what's in your liver i see i see so let's talk about the
+ that will act as a storage supplementing what's in your liver I see I see so let's talk about the
 
 00:57:11.840 --> 00:57:17.600
- optimal number of your store d like what number because obviously some people promote that
+ optimal number of your stored D like what number because obviously some people promote that
 
 00:57:17.600 --> 00:57:24.400
  anything above 20 doesn't make any sense so there's no biological reason for you or advantage to be
 
 00:57:24.400 --> 00:57:33.200
- above 20 and obviously i think you'd promote more of a 40 to 60 number so what would you say
+ above 20 and obviously I think you'd promote more of a 40 to 60 number so what would you say
 
 00:57:33.200 --> 00:57:37.120
  obviously that is what you would say but why would you say the number needs to be higher
 
 00:57:37.120 --> 00:57:45.760
- and and the reasoning behind that one of the functions is to keep your 125 dihydroxy
+ and and the reasoning behind that one of the functions is to keep your 1,25-dihydroxy
 
 00:57:45.760 --> 00:57:57.920
- d as low as possible by keeping your parathyroid hormone low so having excess calcium in in your
+ D as low as possible by keeping your parathyroid hormone low so having excess calcium in in your
 
 00:57:57.920 --> 00:58:08.960
- diet and a generous amount of the 25 hydroxy d that is acting as sort of a buffer against
+ diet and a generous amount of the 25-hydroxy D that is acting as sort of a buffer against
 
 00:58:08.960 --> 00:58:16.560
  any of the irritants and inflammatory de-energized conditions that would threaten to
 
 00:58:17.360 --> 00:58:32.560
- increase your parathyroid hormone and 125 dihydroxy so your go ahead the practical level like improving
+ increase your parathyroid hormone and 1,25-dihydroxy so your go ahead the practical level like improving
 
 00:58:32.560 --> 00:58:42.480
  sleep for example being resistant to sunburn that pretty much happens above 50 nanograms
@@ -1267,49 +1267,49 @@ WEBVTT
  per milliliter 50 to 70 seems to be the safe range where it's acting as a buffer
 
 00:58:51.680 --> 00:59:01.360
- to reduce stress generally and what about some people i mean can you go too high i mean obviously
+ to reduce stress generally and what about some people I mean can you go too high I mean obviously
 
 00:59:01.360 --> 00:59:06.320
  you're not going to go higher than that if you're if you're getting natural sunlight but if you were
 
 00:59:06.320 --> 00:59:13.200
- supplementing i mean what what dangers are there if you if you go to 80 or 90 or 100 people working
+ supplementing I mean what what dangers are there if you if you go to 80 or 90 or 100 people working
 
 00:59:13.200 --> 00:59:23.920
  outdoors for example as a lifeguard have measured 130 nanograms per milliliter and higher
 
 00:59:24.800 --> 00:59:35.600
- and there's no harm evident at all but with a moderate overdose of 125 dihydroxy you can easily
+ and there's no harm evident at all but with a moderate overdose of 1,25-dihydroxy you can easily
 
 00:59:35.600 --> 00:59:44.720
  create hypercalcemia calcification of of soft tissues demineralization of your bones
 
 00:59:45.680 --> 00:59:56.400
- and other degenerative signs so as long as your calcium intake and 25 hydroxy are in that range
+ and other degenerative signs so as long as your calcium intake and 25-hydroxy are in that range
 
 00:59:56.400 --> 01:00:08.000
- i don't know if anyone who has had 200 nanograms per milliliter but no matter how much sun
+ I don't know if anyone who has had 200 nanograms per milliliter but no matter how much sun
 
 01:00:08.800 --> 01:00:20.880
  exposure you get maybe 150 ng per ml would be a an upper healthy limit but
 
 01:00:20.880 --> 01:00:29.200
- it's the keeping keeping the 125 down preventing the parathyroid hormone
+ it's the keeping keeping the 1-25 down preventing the parathyroid hormone
 
 01:00:29.200 --> 01:00:33.840
  from creating the degenerative inflammatory processes
 
 01:00:35.680 --> 01:00:45.120
- so i mean i've read research that will show that a there are healthy people that actually have a low
+ so I mean I've read research that will show that a there are healthy people that actually have a low
 
 01:00:45.120 --> 01:00:52.560
- 25d store d also a low 125d and that would be a healthy person and it's the unhealthy person that
+ 25d stored D also a low 1,25d and that would be a healthy person and it's the unhealthy person that
 
 01:00:52.560 --> 01:01:04.320
- has a elevated or low 25d but then a very elevated 125d i mean can you be healthy with a number
+ has a elevated or low 25d but then a very elevated 125d I mean can you be healthy with a number
 
 01:01:04.320 --> 01:01:18.400
- of 20 for a store d number temporarily i i just think the the long range outlet
+ of 20 for a store d number temporarily I I just think the the long range outlet
 
 01:01:18.400 --> 01:01:22.240
  is better when you're in the higher range because you're
@@ -1330,16 +1330,16 @@ WEBVTT
  in today's modern society with a good amount of stress that would not be an ideal number to be
 
 01:02:07.840 --> 01:02:15.440
- protected for the long haul yeah i think so okay okay so let's talk about the vitamin d kind of
+ protected for the long haul yeah I think so okay okay so let's talk about the vitamin D kind of
 
 01:02:15.440 --> 01:02:22.240
- calcium connection and because obviously i know you definitely your big things that you'd like to
+ calcium connection and because obviously I know you definitely your big things that you'd like to
 
 01:02:22.240 --> 01:02:27.760
- promote thyroid calcium vitamin d and how they all intertwine with each other can you just give me a
+ promote thyroid calcium vitamin D and how they all intertwine with each other can you just give me a
 
 01:02:27.760 --> 01:02:38.160
- brief synopsis of how vitamin d and calcium and thyroid all affect each other i'm keeping the
+ brief synopsis of how vitamin D and calcium and thyroid all affect each other I'm keeping the
 
 01:02:38.160 --> 01:02:50.880
  calcium bound up so that it doesn't act as an excitement to cells the danger when your energy
@@ -1351,10 +1351,10 @@ WEBVTT
  protein nucleic acids and the activation of all of the processes that lead to eventually cell death
 
 01:03:17.600 --> 01:03:32.000
- or loss of function and the vitamin d of the right sort is functioning to activate the proteins
+ or loss of function and the vitamin D of the right sort is functioning to activate the proteins
 
 01:03:32.000 --> 01:03:43.200
- that hold vitamin d in a safe condition and in that condition vitamins or calcium is
+ that hold vitamin D in a safe condition and in that condition vitamins or calcium is
 
 01:03:45.200 --> 01:03:54.560
  working with progesterone and thyroid as cell stabilizers as having actually a sedative effect
@@ -1369,7 +1369,7 @@ WEBVTT
  will activate the improper functions such as calcification of your blood vessels and other
 
 01:04:33.200 --> 01:04:46.160
- soft tissues and that's where at 125 dihydroxy becomes a danger it has a brain excitatory effect
+ soft tissues and that's where at 1,25-dihydroxy becomes a danger it has a brain excitatory effect
 
 01:04:46.160 --> 01:04:56.720
  which can can seem very good momentarily but at exactly the same process that makes it a brain
@@ -1378,7 +1378,7 @@ WEBVTT
  excite and makes it a blood vessel calcifier by destabilizing the relation between calcium
 
 01:05:08.400 --> 01:05:17.040
- and the structure of the cell so i think one of the confusions about calcium is because you always
+ and the structure of the cell so I think one of the confusions about calcium is because you always
 
 01:05:17.040 --> 01:05:23.440
  hear about people are calcified and calcified arteries and blood vessels and their tissue and
@@ -1426,10 +1426,10 @@ WEBVTT
  all of which protects the blood vessels and other soft tissues from calcification
 
 01:07:33.360 --> 01:07:45.680
- injection of the 125 dihydroxy will have exactly the opposite effect or an overdose of parathyroid
+ injection of the 1,25-dihydroxy will have exactly the opposite effect or an overdose of parathyroid
 
 01:07:45.680 --> 01:07:57.440
- hormone activating the 125 dihydroxy will pull calcium out of your bones give you hypercalcemia
+ hormone activating the 1,25-dihydroxy will pull calcium out of your bones give you hypercalcemia
 
 01:07:58.720 --> 01:08:10.560
  and create crystals of calcium and phosphate inside your living cells causing them to first become
@@ -1483,7 +1483,7 @@ WEBVTT
  making you relatively hypercalcimic hardening your arteries and other tissues
 
 01:10:28.720 --> 01:10:35.360
- and so especially at bedtime milk and vitamin g
+ and so especially at bedtime milk and vitamin D
 
 01:10:35.360 --> 01:10:46.960
  are protective against this constant nocturnal loss of calcium so just another reason to have
@@ -1540,7 +1540,7 @@ WEBVTT
  to help kind of support the system during that nighttime yeah and everything that protects
 
 01:13:14.960 --> 01:13:31.680
- against the shift to fat metabolism of free fatty acids the 125 dihydroxy vitamin D is able to turn
+ against the shift to fat metabolism of free fatty acids the 1,25-dihydroxy vitamin D is able to turn
 
 01:13:31.680 --> 01:13:41.440
  off the oxidative metabolism causing a shift over to the fat dependent metabolism and a shift to the
@@ -1549,13 +1549,13 @@ WEBVTT
  cancer metabolism producing uh uh lactic acid why do you think that the doctors do not take
 
 01:13:50.560 --> 01:13:56.880
- the 125 D test i mean do you think that would be more helpful to people to understanding their
+ the 1,25 D test I mean do you think that would be more helpful to people to understanding their
 
 01:13:56.880 --> 01:14:05.920
  own vitamin D status if they'd had both 25 D and 125 D taken um yeah the really useful test is the
 
 01:14:06.720 --> 01:14:19.280
- 25 the unconverted form and some doctors measure the 125
+ 25 the unconverted form and some doctors measure the 1,25
 
 01:14:19.280 --> 01:14:28.480
  dihydroxy and if they don't realize that that's an indicator of more of stress
@@ -1564,16 +1564,16 @@ WEBVTT
  than a vitamin D adequacy that can be a good indicator of vitamin D deficiency when your
 
 01:14:37.440 --> 01:14:47.760
- parathyroid hormone and 125 dihydroxy are increased right so oh just so if you are going to like if
+ parathyroid hormone and 1,25 dihydroxy are increased right so oh just so if you are going to like if
 
 01:14:47.760 --> 01:14:55.120
  you really wanted to understand somebody's vitamin D status what would be the labs that besides 25 D
 
 01:14:55.120 --> 01:15:01.200
- and 125 D that you would have been taped to get to get a really good understanding of where they're
+ and 1,25 D that you would have been taped to get to get a really good understanding of where they're
 
 01:15:01.200 --> 01:15:12.400
- at i think the 25 hydroxy is a good enough test for almost all purposes okay so they wouldn't even
+ at I think the 25 hydroxy is a good enough test for almost all purposes okay so they wouldn't even
 
 01:15:12.400 --> 01:15:20.160
  need to get like parathyroid hormone basically if you're if your 25 D is low you need more vitamin D
@@ -1594,7 +1594,7 @@ WEBVTT
  actively misinforming the public flatly saying that you you cannot lower parathyroid hormone
 
 01:16:11.200 --> 01:16:19.440
- by eating more calcium and vitamin D but that's absolutely not true right yeah and i also saw
+ by eating more calcium and vitamin D but that's absolutely not true right yeah and I also saw
 
 01:16:19.440 --> 01:16:26.000
  studies that just removing phosphorus or eating a low phosphorus diet can improve parathyroid hormone
@@ -1612,7 +1612,7 @@ WEBVTT
  and eating their nut milk so that would be the perfect place to have low vitamin D status
 
 01:17:01.040 --> 01:17:10.800
- right right okay so i real quick i want to get back to just how vitamin D is metabolizes and
+ right right okay so I real quick I want to get back to just how vitamin D is metabolized and
 
 01:17:10.800 --> 01:17:14.960
  talking about the other co-factors the other minerals or nutrients that are involved in that
@@ -1627,7 +1627,7 @@ WEBVTT
  if somebody is already deficient in magnesium and copper and vitamin A would it make more sense to
 
 01:17:38.960 --> 01:17:50.080
- address those issues first before putting a D supplement in i don't think so that's actually
+ address those issues first before putting a D supplement in I don't think so that's actually
 
 01:17:50.880 --> 01:17:59.680
  important to work on all of them at the same time but the vitamin D itself is part of the
@@ -1636,7 +1636,7 @@ WEBVTT
  calming anti-inflammatory process so the calcium and magnesium are essential and should be done
 
 01:18:12.480 --> 01:18:18.880
- immediately but i don't think the vitamin D supplement is going to make anything worse
+ immediately but I don't think the vitamin D supplement is going to make anything worse
 
 01:18:20.320 --> 01:18:24.880
  yeah one of the conversations is if you increase vitamin D you're going to increase kind of the
@@ -1657,7 +1657,7 @@ WEBVTT
  saying is you just need to do it all together but obviously just giving someone D and not doing all
 
 01:18:56.480 --> 01:19:06.480
- the other things you could create a problem i think that idea comes largely from 50 or 60 years ago
+ the other things you could create a problem I think that idea comes largely from 50 or 60 years ago
 
 01:19:07.840 --> 01:19:16.080
  some animal experiments showed that if you give very large amounts of vitamin B1 thiamine
@@ -1666,7 +1666,7 @@ WEBVTT
  that you you will increase the metabolic rate and for borderline deficient in others it will
 
 01:19:25.840 --> 01:19:33.360
- make the other deficiencies show up more quickly but i don't know of any experiments at all
+ make the other deficiencies show up more quickly but I don't know of any experiments at all
 
 01:19:34.080 --> 01:19:45.920
  that would show that happening with vitamin D or magnesium or calcium to a great extent the body can
@@ -1711,7 +1711,7 @@ WEBVTT
  protein and so you'll simply displace one by too much of the other but that is noticeable only in
 
 01:21:54.320 --> 01:22:02.480
- extreme situations i see um i had a thought and then it left my brain
+ extreme situations I see um I had a thought and then it left my brain
 
 01:22:02.480 --> 01:22:10.880
  so we'll go to the next question which is should people ever take a calcium supplement
@@ -1726,7 +1726,7 @@ WEBVTT
  why not powder it up and add it to your omelette it's uh in a in a form that is very assimilable
 
 01:22:48.640 --> 01:22:58.400
- by most people so a calcium carbonate i don't think is is a problem to use as a calcium supplement
+ by most people so a calcium carbonate I don't think is is a problem to use as a calcium supplement
 
 01:22:58.400 --> 01:23:08.000
  calcium supplement but some of the counter ions have their own activity so you don't want to take
@@ -1738,16 +1738,16 @@ WEBVTT
  just because that counter ion can have its own metabolic action okay so taking a food supplement
 
 01:23:27.760 --> 01:23:31.920
- like eggshell calcium which i know i i certainly recommend i know you recommend because it is
+ like eggshell calcium which I know I I certainly recommend I know you recommend because it is
 
 01:23:31.920 --> 01:23:38.080
- actually a food that is safe to take is is there any way you should take that i've always you know
+ actually a food that is safe to take is is there any way you should take that I've always you know
 
 01:23:38.080 --> 01:23:44.160
- read that calcium is better absorbed with sugar or also vitamin d so is it would it be smart to
+ read that calcium is better absorbed with sugar or also vitamin D so is it would it be smart to
 
 01:23:44.160 --> 01:23:49.360
- take that with something like orange juice or yeah yeah i think with the whole meal
+ take that with something like orange juice or yeah yeah I think with the whole meal
 
 01:23:51.200 --> 01:24:00.720
  so you don't notice any highly purified substance tend to disturb and irritate your stomach and
@@ -1777,7 +1777,7 @@ WEBVTT
  not as efficient at absorbing any of the ingredients that your your intestine wants a
 
 01:25:06.000 --> 01:25:13.520
- complex natural sort of mixture of nutrients right i think there's always an argument that
+ complex natural sort of mixture of nutrients right I think there's always an argument that
 
 01:25:13.520 --> 01:25:19.040
  calcium carbonate isn't absorbed very well and would you just say if you consumed it with your
@@ -1786,25 +1786,25 @@ WEBVTT
  complete meal and with some sugar that it would absorb much better yeah it becomes calcium
 
 01:25:24.400 --> 01:25:32.880
- chloride in the presence of stomach acid i see i see okay is there any issues with obviously you
+ chloride in the presence of stomach acid I see I see okay is there any issues with obviously you
 
 01:25:32.880 --> 01:25:37.760
- know i always think milk is a perfect food because it comes with all of the other co-factors like
+ know I always think milk is a perfect food because it comes with all of the other co-factors like
 
 01:25:37.760 --> 01:25:45.120
- vitamin a and d and magnesium all the supporting agents are all together and i feel like that's
+ vitamin A and D and magnesium all the supporting agents are all together and I feel like that's
 
 01:25:45.120 --> 01:25:50.640
  you know kind of how mother nature meant it and so when you do do something like a supplement
 
 01:25:50.640 --> 01:25:57.280
- is there ever a problem to you know just how your body will take it in i've always read if you do
+ is there ever a problem to you know just how your body will take it in I've always read if you do
 
 01:25:57.280 --> 01:26:03.040
  too much calcium you're gonna lower your potassium and you'll just throw off your minerals is that
 
 01:26:03.680 --> 01:26:11.680
- is that going to happen or will your body kind of figure it out i yeah the the receptor idea
+ is that going to happen or will your body kind of figure it out I yeah the the receptor idea
 
 01:26:11.680 --> 01:26:20.720
  leads to a lot of those worries that are unnecessary the the cells and the intestine
@@ -1816,16 +1816,16 @@ WEBVTT
  adjusting what it takes in so that it it uh isn't very easily disturbed
 
 01:26:37.520 --> 01:26:43.760
- okay right because i've heard in circles that if you ingest too much calcium at certain
+ okay right because I've heard in circles that if you ingest too much calcium at certain
 
 01:26:43.760 --> 01:26:50.160
- that somehow you can have a thyroid suppressing effect and i think it's because it was gonna
+ that somehow you can have a thyroid suppressing effect and I think it's because it was gonna
 
 01:26:50.160 --> 01:26:56.640
- lower potassium and other minerals and i and i'm hearing that that's not the case
+ lower potassium and other minerals and I and I'm hearing that that's not the case
 
 01:26:57.840 --> 01:27:01.440
- yes that started i think with some pharmaceutical
+ yes that started I think with some pharmaceutical
 
 01:27:01.440 --> 01:27:09.920
  experiments in which they found that taking a thyroxine supplement at the same time you take
@@ -1843,13 +1843,13 @@ WEBVTT
  is the best for your system to sort out and use properly okay perfect what about you know you
 
 01:27:48.320 --> 01:27:54.240
- always hear about certain ratios of minerals and one in particular that i've heard of is this
+ always hear about certain ratios of minerals and one in particular that I've heard of is this
 
 01:27:54.240 --> 01:28:00.080
  calcium-magnesium ratio where you know you hear hey you need to have almost 10 times as much
 
 01:28:00.080 --> 01:28:05.920
- calcium to magnesium or and then i've also heard the reverse where the magnesium should be much
+ calcium to magnesium or and then I've also heard the reverse where the magnesium should be much
 
 01:28:05.920 --> 01:28:11.200
  higher than the calcium are you just going back to the entire back to that receptor theory that
@@ -1873,13 +1873,13 @@ WEBVTT
  question that and then just so everybody knows we're almost to the finish line which is super
 
 01:29:02.800 --> 01:29:09.680
- exciting but i this has been so interesting um i think a lot of people get this idea this imbalance
+ exciting but I this has been so interesting um I think a lot of people get this idea this imbalance
 
 01:29:09.680 --> 01:29:15.600
  of minerals because they're using a diagnostic test like a hair mineral uh hair tissue mineral
 
 01:29:15.600 --> 01:29:19.920
- analysis tests and i think you get all these ratios on this test and say oh look you're high
+ analysis tests and I think you get all these ratios on this test and say oh look you're high
 
 01:29:19.920 --> 01:29:26.560
  in calcium or you're high in this is that a good test to understand the minerals inside of us
@@ -2047,7 +2047,7 @@ WEBVTT
  is a better source? Years and years ago I experimented with magnesium carbonate.
 
 01:37:20.560 --> 01:37:34.240
- I had used it for in Mexico as a counter action of tourista diarrhea and I always had a little block
+ I had used it for in Mexico as a counteraction of tourista diarrhea and I always had a little block
 
 01:37:34.240 --> 01:37:43.120
  of magnesium carbonate and a doctor friend was complaining about her horrible uterine cramps
@@ -2101,7 +2101,7 @@ WEBVTT
  sometimes the the bowel is being paralyzed by inflammation and so something which is
 
 01:40:09.200 --> 01:40:21.280
- anti-spasmodic can let the normal pericelsus take over. Gotcha well that is all the questions I have
+ antispasmodic can let the normal peristalsis take over. Gotcha well that is all the questions I have
 
 01:40:21.280 --> 01:40:28.800
  I don't know if you have anything else to add Ray that was a lot of amazing information I don't
@@ -2146,7 +2146,7 @@ WEBVTT
  and I think Ray would agree I mean you have to take an excessive amount to really get a
 
 01:41:55.600 --> 01:42:06.720
- harmful effect would you agree? Yeah I've never known a person or even a study of the 25 hydroxy D
+ harmful effect would you agree? Yeah I've never known a person or even a study of the 25-hydroxy D
 
 01:42:06.720 --> 01:42:19.440
  causing harm like five million units continued for a period of time probably can be harmful but

--- a/transcripts/wlfwp-220523-the-truth-about-estrogen-replacement-therapy-calcium-and-milk-myths.vtt
+++ b/transcripts/wlfwp-220523-the-truth-about-estrogen-replacement-therapy-calcium-and-milk-myths.vtt
@@ -19,7 +19,7 @@ WEBVTT
  it's just the overabundance can inhibit it. Can you kind of go over that one more time?
 
 00:00:43.280 --> 00:00:51.680
- It tends to be a vicious circle, but estrogen is one of the estrogen and stress and hypoglycemia
+ It tends to be a vicious circle, but estrogen is one of the, estrogen and stress and hypoglycemia
 
 00:00:52.400 --> 00:00:59.680
  will all activate nitric oxide and progesterone inhibits it partly by keeping steady sugar
@@ -37,10 +37,10 @@ WEBVTT
  know about restoring your metabolism so you can eat more, train less, and lose weight in a healthy
 
 00:01:27.360 --> 00:01:32.880
- and sustainable way. I'm Kenny Blinfield, co-founder of NuStrength and Saturée,
+ and sustainable way. I'm Kitty Blomfield, co-founder of NuStrength and Saturée,
 
 00:01:32.880 --> 00:01:37.920
- creator of Prometabolic Food Supplements and seriously saturated skincare. And today I'm
+ creator of Prometabolic Food Supplements and seriously saturatée skincare. And today I'm
 
 00:01:37.920 --> 00:01:43.280
  really excited to have Dr. Ray Peat and Kate Deering back on the podcast. So we've done
@@ -88,7 +88,7 @@ WEBVTT
  many times as you like. And each month, I actually pick a winner from those that share. So if you'd
 
 00:03:17.040 --> 00:03:23.200
- like to win a tub of Saturated Premium Collagen, all you need to do is take a screenshot of the
+ like to win a tub of Saturatée Premium Collagen, all you need to do is take a screenshot of the
 
 00:03:23.200 --> 00:03:31.920
  review or the podcast episode and share it on Instagram stories and tag me at K-I-T-T-Y-B-L-O-M-F-I-E-L-D.
@@ -97,10 +97,10 @@ WEBVTT
  And like I said, each month, I just pick a winner, pick someone from those that have shared and they
 
 00:03:36.560 --> 00:03:44.960
- get a tub of Saturated Premium Collagen. So look, I hope you learn as much as I did in this episode.
+ get a tub of Saturatée Premium Collagen. So look, I hope you learn as much as I did in this episode.
 
 00:03:44.960 --> 00:03:52.400
- Let's get into it. Super, super excited to welcome back to the podcast, Dr. Ray Peat and Kate Dearing.
+ Let's get into it. Super, super excited to welcome back to the podcast, Dr. Ray Peat and Kate Deering.
 
 00:03:52.400 --> 00:04:00.080
  Hi, guys. Welcome back. Hello, Miss Kitty. How are you today? All good?
@@ -109,7 +109,7 @@ WEBVTT
  Yeah, all good here. Yep. Sure, too. Okay, great. So this is, I think, probably maybe the fifth time
 
 00:04:09.920 --> 00:04:15.120
- we've had Dr. Peat on the podcast. We've had Kate Dearing on the podcast probably 10 plus times.
+ we've had Dr. Peat on the podcast. We've had Kate Deering on the podcast probably 10 plus times.
 
 00:04:15.120 --> 00:04:22.960
  And the last podcast we had, there was quite a lot of questions around
@@ -136,7 +136,7 @@ WEBVTT
  it can make them feel better. And so during the course of this, I was actually referred to a book
 
 00:04:58.800 --> 00:05:05.520
- if people want to look it up called Estrogen Matters by Dr. Avram Blumming and Carol Taveras.
+ if people want to look it up called Estrogen Matters by Dr. Avram Blumming and Carol Tavris.
 
 00:05:05.520 --> 00:05:09.600
  And so I thought we would talk about some of the things that he says in there, because he's
@@ -166,7 +166,7 @@ WEBVTT
  I've been saying that the research shows that estrogen increases clotting, many kinds of
 
 00:06:15.600 --> 00:06:26.320
- inflammation, and other factors relating to platformation, arterial spasms, and so on.
+ inflammation, and other factors relating to plaque formation, arterial spasms, and so on.
 
 00:06:26.320 --> 00:06:36.240
  The progesterone has many life extending properties, especially against heart disease,
@@ -280,7 +280,7 @@ WEBVTT
  promoted by estrogen were, according to articles in medical journals, claimed to cure or prevent
 
 00:12:23.840 --> 00:12:33.920
- exactly that same disease caused. For example, it was widely known that estrogen caused abortions,
+ exactly that same disease it caused. For example, it was widely known that estrogen caused abortions,
 
 00:12:33.920 --> 00:12:42.000
  but they found professors at Harvard who would say that it's a female hormone,
@@ -289,7 +289,7 @@ WEBVTT
  and people who are infertile must be less female. And so if you give them estrogen,
 
 00:12:51.840 --> 00:13:00.320
- it'll make them more feminine and therefore more fertile. So using diethylstilvestrol,
+ it'll make them more feminine and therefore more fertile. So using diethylstilbestrol,
 
 00:13:00.320 --> 00:13:08.400
  they prescribed estrogen ultimately to millions of women,
@@ -562,7 +562,7 @@ WEBVTT
  Okay, that makes sense.
 
 00:24:19.600 --> 00:24:27.840
- Puffa, Puffa, for example, very, very high level of Puffa will lower your ability to make cholesterol.
+ PUFA, PUFA, for example, very, very high level of PUFA will lower your ability to make cholesterol.
 
 00:24:27.840 --> 00:24:33.200
  Yes. Yeah, well, and the same person had a lot of stress going on at this period of time too,
@@ -607,7 +607,7 @@ WEBVTT
  estrogen there, my estrogen, and I can feel like that my brain is working better." So doesn't it
 
 00:26:09.680 --> 00:26:18.400
- have a slight excitatory effect on the brain? It is excitatory. Catharina Dalton in the 1940s
+ have a slight excitatory effect on the brain? It is excitatory. Katharina Dalton in the 1940s
 
 00:26:18.400 --> 00:26:29.040
  and 50s was doing good studies on treating her patients for premature birth, toxemia,
@@ -793,7 +793,7 @@ WEBVTT
  covered 350,000 cases of breast cancer. And then you have the one like the recent
 
 00:36:09.040 --> 00:36:20.640
- Japanese study of 164 cases. And people like Blooming and Taveras go with the results
+ Japanese study of 164 cases. And people like Bluming and Tavris go with the results
 
 00:36:22.000 --> 00:36:32.720
  based on 164 cases in Japan rather than 350,000 cases in the US, which are strongly supported
@@ -808,7 +808,7 @@ WEBVTT
  So that's an interesting place to look. I haven't even heard of that in the SEER study.
 
 00:36:57.040 --> 00:37:10.720
- Probably the biggest, most obvious disprove of people like the spoke you mentioned
+ Probably the biggest, most obvious disproof of people like the spoke you mentioned
 
 00:37:12.800 --> 00:37:25.760
  is that in 2002, when the data from the study were published, there was a tremendous drop off
@@ -1072,7 +1072,7 @@ WEBVTT
  a better absorption. Is that right? Yeah, except even when orange juice, the citric acid
 
 00:50:00.560 --> 00:50:10.640
- isn't an official thing. The best orange juice has almost no citric acid, it's a side of stress.
+ isn't an official thing. The best orange juice has almost no citric acid, it's a sign of stress.
 
 00:50:10.640 --> 00:50:16.800
  Yeah, consuming calcium carbonate with the orange juice with the sugar would help facilitate
@@ -1126,7 +1126,7 @@ WEBVTT
  calcium and vitamin D, that you inhibit the parathyroid hormone and also inhibit the conversion
 
 00:52:40.480 --> 00:52:52.640
- of 25-hydroxy vitamin D into one 25-hydroxy vitamin D, which is called the active
+ of 25-hydroxy vitamin D into  1,25-hydroxy vitamin D, which is called the active
 
 00:52:53.440 --> 00:53:02.480
  vitamin D, but actually it's a stress-related factor that goes with all of the toxic effects of
@@ -1153,10 +1153,10 @@ WEBVTT
  so with that person, they could be creating hypercalcemia or calcium in the tissue. Is that
 
 00:53:53.680 --> 00:54:02.000
- correct? Yeah, the combination of vitamin D in the dieter from sunlight plus adequate calcium
+ correct? Yeah, the combination of vitamin D in the diet or from sunlight plus adequate calcium
 
 00:54:02.000 --> 00:54:15.200
- and magnesium is necessary to keep a parathyroid hormone down and the active 125-hydroxy vitamin D
+ and magnesium is necessary to keep a parathyroid hormone down and the active 1,25-hydroxy vitamin D
 
 00:54:15.200 --> 00:54:22.720
  down. Okay, so I just want people to understand that because there's a lot of D controversy,
@@ -1384,7 +1384,7 @@ WEBVTT
  dairies that I've tried to drink the organic milk from, and the milk tastes so bad. In one of the
 
 01:04:55.760 --> 01:05:08.560
- cases, I looked on the map and there's a factory on I-5, I think it was called Wotang, that produced
+ cases, I looked on the map and there is a factory on I-5, I think it was called Wotang, that produced
 
 01:05:08.560 --> 01:05:17.840
  a toxic metal for the government military, and the odor permeates miles around it.
@@ -1405,7 +1405,7 @@ WEBVTT
  allowed their cows to graze on weeds rather than known grass or clover, and many weeds are very
 
 01:06:04.000 --> 01:06:11.360
- bad-facing. Many of them are allergenic. Breastfeeding women often have the experience that
+ bad-tasting. Many of them are allergenic. Breastfeeding women often have the experience that
 
 01:06:11.360 --> 01:06:21.120
  if they eat certain foods, the baby becomes constipated or develops related symptoms
@@ -1474,7 +1474,7 @@ WEBVTT
  Yeah, some of the studies are based on chemical breakdown of casein. And then even chemically
 
 01:08:49.120 --> 01:08:57.280
- hydrolyzing it, which is not the same as detesting it in your stomach and intestine. They test
+ hydrolyzing it, which is not the same as digesting it in your stomach and intestine. They test
 
 01:08:58.800 --> 01:09:06.960
  the toxicity of the broken down casein. For example, by injecting it into a mouse brain,
@@ -1633,7 +1633,7 @@ WEBVTT
  Yes, they are out in full force these days. What about people who drink milk and they say,
 
 01:15:46.080 --> 01:15:53.360
- milk is giving me acne. What would you say is going on there? Milk does flat. Gives them
+ milk is giving me acne. What would you say is going on there? Milk does what? Gives them
 
 01:15:53.360 --> 01:16:02.160
  acne. They start to get acne on their skin. Yeah, maybe they're drinking too much fat with it.
@@ -1642,7 +1642,7 @@ WEBVTT
  Any kind of fat in excess will disturb your skin energy production. And for any cell,
 
 01:16:18.080 --> 01:16:25.520
- its functions decrease under the influence of fat that doesn't trigger.
+ its functions decrease under the influence of fat rather than sugar.
 
 01:16:25.520 --> 01:16:31.120
  So if someone thinks that they're drinking milk and they're getting acne,
@@ -1789,7 +1789,7 @@ WEBVTT
  As cooked greens have a very high ratio of calcium to phosphorus. And the ratio is of
 
 01:22:58.640 --> 01:23:09.040
- major importance. Because too much phosphate turns on the paracyroid hormone, turns off
+ major importance. Because too much phosphate turns on the parathyroid hormone, turns off
 
 01:23:09.840 --> 01:23:18.000
  useful energy production, and so on. So the excitatory effect of inorganic phosphate
@@ -1813,7 +1813,7 @@ WEBVTT
  in the ATP, for example, gives them a very high ratio of phosphate to calcium, nuts, grains,
 
 01:24:14.960 --> 01:24:27.280
- legumes. In general, the reproductive tissues are the phosphate is present.
+ legumes. In general, the reproductive tissues are, the phosphate is present.
 
 01:24:27.280 --> 01:24:35.200
  So that the storage material can be turned into growth material.
@@ -1831,13 +1831,13 @@ WEBVTT
  that with the meat, and maybe minimizing the grains and the beans and the nuts would be
 
 01:25:13.040 --> 01:25:19.840
- advantageous. Yeah. What about just because I'm obsessed with this lately? Masaharina,
+ advantageous. Yeah. What about just because I'm obsessed with this lately? Masa harina,
 
 01:25:19.840 --> 01:25:28.000
  is that a decent source of calcium? Oh, yeah, because they add, they boil it in a calcium
 
 01:25:28.000 --> 01:25:41.280
- hydroxide and as cheap for overnight. So it soaks up a lot of calcium. My dentist in Mexico says
+ hydroxide and let it sits for overnight. So it soaks up a lot of calcium. My dentist in Mexico says
 
 01:25:42.080 --> 01:25:50.720
  in her area where people eat no bread, but lots of tortillas, even people in their 80s who
@@ -1849,16 +1849,16 @@ WEBVTT
  because their their jaws and teeth are so well constructed from a chronically good ratio of
 
 01:26:08.160 --> 01:26:13.040
- calcium to phosphate. So the masaharina doesn't have a lot of phosphate in it.
+ calcium to phosphate. So the masa harina doesn't have a lot of phosphate in it.
 
 01:26:13.040 --> 01:26:23.040
- Not compared to the calcium. Okay, so everybody gets some masaharina makes them your own tortillas.
+ Not compared to the calcium. Okay, so everybody gets some masa harina makes them your own tortillas.
 
 01:26:23.040 --> 01:26:30.800
  It's very, very good for you. I can't think of anything else, Kitty. I don't know you've been
 
 01:26:30.800 --> 01:26:34.960
- sitting there. Is there any other questions you'd like to ask Greg? I don't think so. I've just been
+ sitting there. Is there any other questions you'd like to ask Ray? I don't think so. I've just been
 
 01:26:34.960 --> 01:26:41.200
  listening intently, learning so much. It's amazing. This is a really good episode and it was really
@@ -1891,7 +1891,7 @@ WEBVTT
  disappearance of science from our culture, it's very important for everyone to think about.
 
 01:27:57.440 --> 01:28:06.000
- His last name is Felp, K-I-R-S-C-H. Yes, and he looks like he has a sub-stack. I'm just googling
+ His last name is Felp, K-I-R-S-C-H. Yes, and he looks like he has a substack. I'm just googling
 
 01:28:06.000 --> 01:28:12.880
  him right now. So yeah, you kind of touched on him and we were discussing the estrogen therapy
@@ -1930,10 +1930,10 @@ WEBVTT
  I have no idea how you keep up with all that, but God bless you.
 
 01:29:33.680 --> 01:29:42.480
- I go when people's things expire after three years. Amazing. It is amazing. Well, thank you
+ I go when people's things, expire after three years. Amazing. It is amazing. Well, thank you
 
 01:29:42.480 --> 01:29:47.840
- again, both Kenny and Ray. Thank you so much. Thanks so much, Ray. Thanks, Kate. And I know Kate's got
+ again, both Kitty and Ray. Thank you so much. Thanks so much, Ray. Thanks, Kate. And I know Kate's got
 
 01:29:47.840 --> 01:29:51.840
  a, we'll have you on again, Ray. I know Kate's got a few other topics that she wants to dive


### PR DESCRIPTION
Fix nearly all typos in the Weight Loss For Women Podcasts 210404, 210701, 2205023. I couldn't fix the following typos because I don't understand what it's being said:

`210404`
- 01:29:03.680 --> 01:29:11.520
 question Emma uh no no that's fantastic yeah it's good eat the sugar everyone plus it's Haitian 
 (https://github.com/peatysharing/raypeatarchive/blob/b38899ae2a9e144aad0d672eb276f63b4f4e52b9/transcripts/wlfwp-210404-all-things-hormones-metabolism-and-health.vtt#L1819)

- 01:50:47.920 --> 01:50:57.600
 miskin's miscarriage or it kills the embryo even before it can implant
 (https://github.com/peatysharing/raypeatarchive/blob/b38899ae2a9e144aad0d672eb276f63b4f4e52b9/transcripts/wlfwp-210404-all-things-hormones-metabolism-and-health.vtt#L2329)

`220131`
- 01:20:53.800 --> 01:20:57.200
 He couldn't see the train itself.
(https://github.com/0x2447196/raypeatarchive/blob/main/transcripts/wlfwp-220131-the-estrogen-industry-the-magic-of-progesterone-and-the%20importance-of-thyroid.vtt#L3478)